### PR TITLE
Fixing spacing for Mono tags

### DIFF
--- a/gui/xmlparserthread.cpp
+++ b/gui/xmlparserthread.cpp
@@ -22,6 +22,7 @@ XmlParserThread::XmlParserThread(QObject *parent) {
     connect(this, SIGNAL(updateThoughtsWindow(QString)), windowFacade, SLOT(updateThoughtsWindow(QString)));
     connect(this, SIGNAL(updateArrivalsWindow(QString)), windowFacade, SLOT(updateArrivalsWindow(QString)));
     connect(this, SIGNAL(updateFamiliarWindow(QString)), windowFacade, SLOT(updateFamiliarWindow(QString)));
+    connect(this, SIGNAL(updateStoreWindow(QString)), windowFacade, SLOT(updateStoreWindow(QString)));
 
     connect(this, SIGNAL(updateVitals(QString, QString)), toolBar, SLOT(updateVitals(QString, QString)));
     connect(this, SIGNAL(updateStatus(QString, QString)), toolBar, SLOT(updateStatus(QString, QString)));
@@ -117,6 +118,8 @@ void XmlParserThread::processGameData(QByteArray data) {
         n = n.nextSibling();
     }
 
+    //qDebug() << "Raw data is: " << rawData;
+
     // process pushstream
     processPushStream(rawData);
 
@@ -164,6 +167,8 @@ bool XmlParserThread::filterPlainText(QDomElement root, QDomNode n) {
             QString d = e.text().trimmed();
             TextUtils::Instance()->plainToHtml(d);
             gameText += d;
+
+            emit updateStoreWindow(d);
         } else if(e.tagName() == "preset" && e.attribute("id") == "roomDesc") {            
             QString preset = e.text().trimmed();
             TextUtils::Instance()->plainToHtml(preset);
@@ -451,7 +456,10 @@ void XmlParserThread::writeGameText(QByteArray rawData) {
         this->fixMonoTags(line);
 
         if(!rawData.startsWith("<output class=\"mono\"/>")) {
-            emit writeText(line.toLocal8Bit(), false);
+            auto theLine = line.toLocal8Bit();
+            if(theLine != "") {
+                emit writeText(line.toLocal8Bit(), false);
+            }
         }
     } else if(gameText != "") {
         emit writeText(gameText.toLocal8Bit(), prompt);

--- a/gui/xmlparserthread.cpp
+++ b/gui/xmlparserthread.cpp
@@ -166,8 +166,6 @@ bool XmlParserThread::filterPlainText(QDomElement root, QDomNode n) {
             QString d = e.text().trimmed();
             TextUtils::Instance()->plainToHtml(d);
             gameText += d;
-
-            emit updateStoreWindow(d);
         } else if(e.tagName() == "preset" && e.attribute("id") == "roomDesc") {            
             QString preset = e.text().trimmed();
             TextUtils::Instance()->plainToHtml(preset);

--- a/gui/xmlparserthread.cpp
+++ b/gui/xmlparserthread.cpp
@@ -117,8 +117,6 @@ void XmlParserThread::processGameData(QByteArray data) {
         n = n.nextSibling();
     }
 
-    //qDebug() << "Raw data is: " << rawData;
-
     // process pushstream
     processPushStream(rawData);
 


### PR DESCRIPTION
References and a fix for issue: https://github.com/matoom/frostbite/issues/8

Tested with both Lich running and without Lich running. Tried maneuvering Lich code around to get it to work with FB, but it would've been a lot of very specific changes in the code on that end to make it work for Frostbite. Seemed the cleaner solution to add the change on this end. However, you'll know better than I if this change could have cascading effects to other aspects of the FE I wasn't able to test.