### PR TITLE
External command-line dictionary support

### DIFF
--- a/gui/defaultvalues.h
+++ b/gui/defaultvalues.h
@@ -64,6 +64,9 @@
 #define DEFAULT_CMD_RT_COLOR "#E86850"
 #define DEFAULT_CMD_CT_COLOR "#66A7C5"
 
+#define DEFAULT_DICT_CMD "dict"
+#define DEFAULT_DICT_ARGS ""
+
 #define WINDOW_TITLE_MAIN "Main"
 
 #define DOCK_TITLE_DEATHS "Deaths"
@@ -78,6 +81,7 @@
 #define DOCK_TITLE_MAP "Map"
 #define DOCK_TITLE_ATMOSPHERICS "Atmospherics"
 #define DOCK_TITLE_COMBAT "Combat"
+#define DOCK_TITLE_DICTIONARY "Dictionary"
 
 #define SCRIPT_ENTRY QApplication::applicationDirPath() + "/scripts/lib/main.rb"
 #define SCRIPT_INTERPRETER "ruby"

--- a/gui/defaultvalues.h
+++ b/gui/defaultvalues.h
@@ -66,6 +66,8 @@
 
 #define DEFAULT_DICT_CMD "dict"
 #define DEFAULT_DICT_ARGS ""
+#define DEFAULT_DICT_DBLCLK_ENABLED false
+#define DEFAULT_DICT_DBLCLK_MOD Qt::NoModifier
 
 #define WINDOW_TITLE_MAIN "Main"
 

--- a/gui/dict/dict.pri
+++ b/gui/dict/dict.pri
@@ -1,0 +1,9 @@
+HEADERS += \
+    $$PWD/dictionarydialog.h \
+    $$PWD/dictionarysettings.h \
+    $$PWD/dictionaryservice.h 
+
+SOURCES += \
+    $$PWD/dictionarydialog.cpp \
+    $$PWD/dictionarysettings.cpp \
+    $$PWD/dictionaryservice.cpp

--- a/gui/dict/dictionarydialog.cpp
+++ b/gui/dict/dictionarydialog.cpp
@@ -1,9 +1,27 @@
 #include "dictionarydialog.h"
 #include "dictionarysettings.h"
+#include "qnamespace.h"
+
 #include <QPushButton>
 #include <QGridLayout>
 #include <QLineEdit>
 #include <QLabel>
+#include <QGroupBox>
+#include <QVBoxLayout>
+#include <QRadioButton>
+
+#include <algorithm>
+
+namespace {
+struct FindModifier {
+    FindModifier(const Qt::KeyboardModifier mod) : modifier(mod) {}
+    bool operator()(const DictionaryDialog::ButtonPair& pair) {
+        return pair.first == modifier;
+    }
+    Qt::KeyboardModifier modifier;
+};
+} // anonymous
+
 
 DictionaryDialog::DictionaryDialog(QWidget *parent) : QDialog(parent), settings(DictionarySettings::getInstance()) {
     setWindowTitle(tr("Dictionary settings"));
@@ -17,6 +35,21 @@ DictionaryDialog::DictionaryDialog(QWidget *parent) : QDialog(parent), settings(
     dictNameEdit = new QLineEdit("", this);
     dictArgumentsEdit = new QLineEdit("", this);
 
+    hotkeyOptionsBox = new QGroupBox(tr("Enable Double-click to translate"), this);
+    hotkeyOptionsBox->setCheckable(true);
+    hotkeyOptionsBox->setChecked(false);
+
+    QVBoxLayout *vbox = new QVBoxLayout;
+    dblClkButtons.push_back(std::make_pair(Qt::NoModifier, new QRadioButton(tr("Double click"))));
+    dblClkButtons.push_back(std::make_pair(Qt::AltModifier, new QRadioButton(tr("Alt + Double click"))));
+    dblClkButtons.push_back(std::make_pair(Qt::ControlModifier, new QRadioButton(tr("Ctrl + Double click"))));
+    dblClkButtons.push_back(std::make_pair(Qt::ShiftModifier, new QRadioButton(tr("Shift + Double click"))));
+    for (size_t i = 0; i < dblClkButtons.size(); ++ i) {
+        vbox->addWidget(dblClkButtons[i].second);
+    }
+    vbox->addStretch(1);
+    hotkeyOptionsBox->setLayout(vbox);
+    dblClkButtons[0].second->setChecked(true);
     loadSettings();
     
     QGridLayout *mainLayout = new QGridLayout(this);
@@ -24,15 +57,16 @@ DictionaryDialog::DictionaryDialog(QWidget *parent) : QDialog(parent), settings(
     mainLayout->addWidget(dictNameEdit, 0, 1, 1, 3);
     mainLayout->addWidget(new QLabel(tr("Command line arguments:")), 1, 0);
     mainLayout->addWidget(dictArgumentsEdit, 1, 1, 1, 3);
-    mainLayout->addWidget(okButton, 2, 2);
-    mainLayout->addWidget(cancelButton, 2, 3);    
+    mainLayout->addWidget(hotkeyOptionsBox, 2, 0, 1, 4);
+    mainLayout->addWidget(okButton, 3, 2);
+    mainLayout->addWidget(cancelButton, 3, 3);    
 }
 
 DictionaryDialog::~DictionaryDialog() {
 }
 
 void DictionaryDialog::okPressed() {
-    this->saveChanges();
+    this->saveSettings();
     this->loadSettings();
     this->accept();
 }
@@ -45,10 +79,27 @@ void DictionaryDialog::cancelPressed() {
 void DictionaryDialog::loadSettings() {
     dictNameEdit->setText(settings->getDictCommand());
     dictArgumentsEdit->setText(settings->getDictArguments());
+    hotkeyOptionsBox->setChecked(settings->getDoubleClickEnabled());
+    
+    ButtonVector::iterator found = std::find_if(dblClkButtons.begin(),
+                                                dblClkButtons.end(),
+                                                FindModifier(settings->getDoubleClickModifier()));
+    if (found != dblClkButtons.end()) {
+        found->second->setChecked(true);
+    }
 }
 
 
-void DictionaryDialog::saveChanges() {
-  settings->setDictCommand(dictNameEdit->text())
-      .setDictArguments(dictArgumentsEdit->text());
+void DictionaryDialog::saveSettings() {
+    Qt::KeyboardModifier modifier = Qt::NoModifier;
+    for (size_t i = 0; i < dblClkButtons.size(); ++ i) {
+        if (dblClkButtons[i].second->isChecked()) {
+            modifier = dblClkButtons[i].first;
+        }
+    }
+
+    settings->setDictCommand(dictNameEdit->text())
+        .setDictArguments(dictArgumentsEdit->text())
+        .setDoubleClickEnabled(hotkeyOptionsBox->isChecked())
+        .setDoubleClickModifier(modifier);
 }

--- a/gui/dict/dictionarydialog.cpp
+++ b/gui/dict/dictionarydialog.cpp
@@ -4,7 +4,6 @@
 #include <QGridLayout>
 #include <QLineEdit>
 #include <QLabel>
-#include <QMessageBox>
 
 DictionaryDialog::DictionaryDialog(QWidget *parent) : QDialog(parent), settings(DictionarySettings::getInstance()) {
     setWindowTitle(tr("Dictionary settings"));

--- a/gui/dict/dictionarydialog.cpp
+++ b/gui/dict/dictionarydialog.cpp
@@ -1,0 +1,55 @@
+#include "dictionarydialog.h"
+#include "dictionarysettings.h"
+#include <QPushButton>
+#include <QGridLayout>
+#include <QLineEdit>
+#include <QLabel>
+#include <QMessageBox>
+
+DictionaryDialog::DictionaryDialog(QWidget *parent) : QDialog(parent), settings(DictionarySettings::getInstance()) {
+    setWindowTitle(tr("Dictionary settings"));
+
+    QPushButton *okButton = new QPushButton(tr("Ok"), this);
+    QPushButton *cancelButton = new QPushButton(tr("Cancel"), this);
+    
+    connect(okButton, SIGNAL(clicked()), this, SLOT(okPressed()));
+    connect(cancelButton, SIGNAL(clicked()), this, SLOT(cancelPressed()));
+
+    dictNameEdit = new QLineEdit("", this);
+    dictArgumentsEdit = new QLineEdit("", this);
+
+    loadSettings();
+    
+    QGridLayout *mainLayout = new QGridLayout(this);
+    mainLayout->addWidget(new QLabel(tr("Dictionary program name:")), 0, 0);
+    mainLayout->addWidget(dictNameEdit, 0, 1, 1, 3);
+    mainLayout->addWidget(new QLabel(tr("Command line arguments:")), 1, 0);
+    mainLayout->addWidget(dictArgumentsEdit, 1, 1, 1, 3);
+    mainLayout->addWidget(okButton, 2, 2);
+    mainLayout->addWidget(cancelButton, 2, 3);    
+}
+
+DictionaryDialog::~DictionaryDialog() {
+}
+
+void DictionaryDialog::okPressed() {
+    this->saveChanges();
+    this->loadSettings();
+    this->accept();
+}
+
+void DictionaryDialog::cancelPressed() {
+    this->loadSettings();
+    this->reject();
+}
+
+void DictionaryDialog::loadSettings() {
+    dictNameEdit->setText(settings->getDictCommand());
+    dictArgumentsEdit->setText(settings->getDictArguments());
+}
+
+
+void DictionaryDialog::saveChanges() {
+  settings->setDictCommand(dictNameEdit->text())
+      .setDictArguments(dictArgumentsEdit->text());
+}

--- a/gui/dict/dictionarydialog.h
+++ b/gui/dict/dictionarydialog.h
@@ -2,18 +2,25 @@
 #define DICTIONARYDIALOG_H
 
 #include <QDialog>
+#include <vector>
+#include <utility>
 
+class QRadioButton;
 class QLineEdit;
 class DictionarySettings;
+class QGroupBox;
 
 class DictionaryDialog : public QDialog {
     Q_OBJECT
+public:
+    typedef std::pair<Qt::KeyboardModifier, QRadioButton*> ButtonPair;
+    
 public:
     explicit DictionaryDialog(QWidget *parent = 0);
     ~DictionaryDialog();
 
 private:
-    void saveChanges();
+    void saveSettings();
     void loadSettings();
 
 private slots:
@@ -24,8 +31,11 @@ private slots:
 private:
     QLineEdit* dictNameEdit;
     QLineEdit* dictArgumentsEdit;
-
+    QGroupBox* hotkeyOptionsBox;
+    
     DictionarySettings* settings;
+    typedef std::vector<ButtonPair> ButtonVector;
+    ButtonVector dblClkButtons;
 };
 
 #endif // DICTIONARYDIALOG_H

--- a/gui/dict/dictionarydialog.h
+++ b/gui/dict/dictionarydialog.h
@@ -1,0 +1,31 @@
+#ifndef DICTIONARYDIALOG_H
+#define DICTIONARYDIALOG_H
+
+#include <QDialog>
+
+class QLineEdit;
+class DictionarySettings;
+
+class DictionaryDialog : public QDialog {
+    Q_OBJECT
+public:
+    explicit DictionaryDialog(QWidget *parent = 0);
+    ~DictionaryDialog();
+
+private:
+    void saveChanges();
+    void loadSettings();
+
+private slots:
+    void okPressed();
+    void cancelPressed();
+
+
+private:
+    QLineEdit* dictNameEdit;
+    QLineEdit* dictArgumentsEdit;
+
+    DictionarySettings* settings;
+};
+
+#endif // DICTIONARYDIALOG_H

--- a/gui/dict/dictionaryservice.cpp
+++ b/gui/dict/dictionaryservice.cpp
@@ -1,0 +1,38 @@
+#include "dictionaryservice.h"
+#include "dictionarysettings.h"
+
+#include <QMessageBox>
+
+DictionaryService::DictionaryService(QObject* parent) :
+    QObject(parent),
+    settings(DictionarySettings::getInstance()),
+    process(new QProcess(this)) {
+    connect(process, SIGNAL(errorOccurred(QProcess::ProcessError)),
+            this, SLOT(processErrorOccurred(QProcess::ProcessError)));
+    connect(process, SIGNAL(finished(int, QProcess::ExitStatus)),
+            this, SLOT(processFinished(int, QProcess::ExitStatus)));
+}
+
+DictionaryService::~DictionaryService() {}
+
+void DictionaryService::translate(const QString &word) {
+    if (word.size() > 3)
+        emit translationFinished("translation\n");
+    else {
+        emit translationFailed("Not Found\n");
+    }
+}
+
+
+void DictionaryService::processErrorOccurred(QProcess::ProcessError error) {
+    emit translationFailed("Unable to execute dictionary\n");
+}
+
+void DictionaryService::processFinished(int exitCode, QProcess::ExitStatus exitStatus) {
+    if (exitCode != 0) {
+        emit translationFailed("Word not found\n");
+    } else {
+        QString translation = process->readAllStandardOutput();
+        emit translationFinished(translation);
+    }
+}

--- a/gui/dict/dictionaryservice.cpp
+++ b/gui/dict/dictionaryservice.cpp
@@ -53,13 +53,18 @@ void DictionaryService::processErrorOccurred(QProcess::ProcessError error) {
 void DictionaryService::processFinished(int exitCode, QProcess::ExitStatus exitStatus) {
     switch (exitStatus) {
     case QProcess::NormalExit:
-        if (exitCode == 0 || exitCode == 21) {
-            // 21 is the error code for dict meaning
-            // "Approximate matches found"
+        switch (exitCode) {
+        case 0: {
             QString translation = process->readAllStandardOutput();
+            emit translationFinished(translation);                        
+        } break;
+        case 21: { // dict error code "Approximate matches found"
+            QString translation = process->readAllStandardError();
             emit translationFinished(translation);            
-        } else {
+        } break;
+        default:
             emitError("Word not found");
+            break;
         }
         break;
     default:

--- a/gui/dict/dictionaryservice.cpp
+++ b/gui/dict/dictionaryservice.cpp
@@ -1,8 +1,6 @@
 #include "dictionaryservice.h"
 #include "dictionarysettings.h"
 
-#include <QMessageBox>
-
 DictionaryService::DictionaryService(QObject* parent) :
     QObject(parent),
     settings(DictionarySettings::getInstance()),
@@ -16,23 +14,61 @@ DictionaryService::DictionaryService(QObject* parent) :
 DictionaryService::~DictionaryService() {}
 
 void DictionaryService::translate(const QString &word) {
-    if (word.size() > 3)
-        emit translationFinished("translation\n");
-    else {
-        emit translationFailed("Not Found\n");
+    if (process->state() == QProcess::NotRunning) {
+        QStringList args;
+        args = settings->getDictArguments().split(" ");
+        args << word;
+        process->start(settings->getDictCommand(), args);
+    } else {
+        emitError("Dictionary process is already running");
     }
 }
 
 
 void DictionaryService::processErrorOccurred(QProcess::ProcessError error) {
-    emit translationFailed("Unable to execute dictionary\n");
+    QString reason;
+    switch (error) {
+    case QProcess::FailedToStart:
+        reason = "File not found, resource error";
+        break;
+    case QProcess::Crashed:
+        reason = "Process crashed";
+        break;
+    case QProcess::Timedout:
+        reason = "Process timed out";
+        break;
+    case QProcess::ReadError:
+        reason = "Read error";
+        break;
+    case QProcess::WriteError:
+        reason = "Write error";
+        break;
+    default:
+        reason = "Unknown error";
+        break;
+    }
+    emitError(reason);
 }
 
 void DictionaryService::processFinished(int exitCode, QProcess::ExitStatus exitStatus) {
-    if (exitCode != 0) {
-        emit translationFailed("Word not found\n");
-    } else {
-        QString translation = process->readAllStandardOutput();
-        emit translationFinished(translation);
+    switch (exitStatus) {
+    case QProcess::NormalExit:
+        if (exitCode == 0 || exitCode == 21) {
+            // 21 is the error code for dict meaning
+            // "Approximate matches found"
+            QString translation = process->readAllStandardOutput();
+            emit translationFinished(translation);            
+        } else {
+            emitError("Word not found");
+        }
+        break;
+    default:
+        emitError("Process crashed");
+        break;
     }
+}
+
+
+void DictionaryService::emitError(const QString& reason) {
+    emit translationFailed("(Error: " + reason + ")\n");
 }

--- a/gui/dict/dictionaryservice.h
+++ b/gui/dict/dictionaryservice.h
@@ -2,8 +2,6 @@
 #define DICTIONARYSERVICE_H
 
 #include <QObject>
-#include <QMutex>
-#include <QQueue>
 #include <QProcess>
 
 class DictionarySettings;
@@ -21,11 +19,13 @@ public:
     ~DictionaryService();
 
     void translate(const QString& word);
-    
 signals:
     void translationFinished(QString translation);
     void translationFailed(QString reason);
 
+private:
+    void emitError(const QString& reason);
+        
 private slots:
     void processErrorOccurred(QProcess::ProcessError error);
     void processFinished(int exitCode, QProcess::ExitStatus exitStatus);
@@ -33,8 +33,6 @@ private slots:
 private:
     DictionarySettings *settings;
     QProcess* process;
-    QMutex mutex;
-    QQueue<QString> wordQueue;
 };
 
 #endif // DICTIONARYSERVICE_H

--- a/gui/dict/dictionaryservice.h
+++ b/gui/dict/dictionaryservice.h
@@ -1,0 +1,40 @@
+#ifndef DICTIONARYSERVICE_H
+#define DICTIONARYSERVICE_H
+
+#include <QObject>
+#include <QMutex>
+#include <QQueue>
+#include <QProcess>
+
+class DictionarySettings;
+
+class DictionaryService : public QObject {
+    Q_OBJECT
+public:
+  enum ErrorCode {
+    UnableToExecuteDict,
+    WordNotFound
+  };
+
+public:
+    explicit DictionaryService(QObject *parent);
+    ~DictionaryService();
+
+    void translate(const QString& word);
+    
+signals:
+    void translationFinished(QString translation);
+    void translationFailed(QString reason);
+
+private slots:
+    void processErrorOccurred(QProcess::ProcessError error);
+    void processFinished(int exitCode, QProcess::ExitStatus exitStatus);
+    
+private:
+    DictionarySettings *settings;
+    QProcess* process;
+    QMutex mutex;
+    QQueue<QString> wordQueue;
+};
+
+#endif // DICTIONARYSERVICE_H

--- a/gui/dict/dictionarysettings.cpp
+++ b/gui/dict/dictionarysettings.cpp
@@ -10,6 +10,8 @@ Q_GLOBAL_STATIC(DictionarySettingsInstance, uniqueInstance)
 namespace {
 const char* DICTIONARY_NAME_PATH = "Dictionary/Command";
 const char* DICTIONARY_ARGS_PATH = "Dictionary/Arguments";
+const char* DICTIONARY_DBLCLICK_PATH = "Dictionary/DoubleClickEnabled";
+const char* DICTIONARY_DBLCLICK_MOD_PATH = "Dictionary/DoubleClickModifier";
 }
 
 
@@ -33,6 +35,32 @@ QString DictionarySettings::getDictArguments() const {
                                         DEFAULT_DICT_ARGS).toString();
 }
 
+bool DictionarySettings::getDoubleClickEnabled() const {
+    return clientSettings->getParameter(DICTIONARY_DBLCLICK_PATH,
+                                        DEFAULT_DICT_DBLCLK_ENABLED).toBool();
+}
+
+Qt::KeyboardModifier DictionarySettings::getDoubleClickModifier() const {
+    bool ok;
+    uint modifierVal = clientSettings->getParameter(DICTIONARY_DBLCLICK_MOD_PATH,
+                                                    DEFAULT_DICT_DBLCLK_MOD).toUInt(&ok);
+    // Accept only known modifiers
+    Qt::KeyboardModifier modifier = DEFAULT_DICT_DBLCLK_MOD;
+    if (ok) {
+        switch (modifierVal) {
+        case Qt::ShiftModifier:
+        case Qt::ControlModifier:
+        case Qt::AltModifier:
+            modifier = static_cast<Qt::KeyboardModifier>(modifierVal);
+            break;
+        default:
+            break;
+        };
+    }
+    return modifier;
+}
+
+
 DictionarySettings& DictionarySettings::setDictCommand(const QString &cmd) {
     clientSettings->setParameter(DICTIONARY_NAME_PATH, cmd);
     return *this;
@@ -40,6 +68,16 @@ DictionarySettings& DictionarySettings::setDictCommand(const QString &cmd) {
 
 DictionarySettings& DictionarySettings::setDictArguments(const QString& args) {
     clientSettings->setParameter(DICTIONARY_ARGS_PATH, args);
+    return *this;
+}
+
+DictionarySettings& DictionarySettings::setDoubleClickEnabled(bool enabled) {
+    clientSettings->setParameter(DICTIONARY_DBLCLICK_PATH, enabled);
+    return *this;
+}
+
+DictionarySettings& DictionarySettings::setDoubleClickModifier(Qt::KeyboardModifier modifier) {
+    clientSettings->setParameter(DICTIONARY_DBLCLICK_MOD_PATH, modifier);
     return *this;
 }
 

--- a/gui/dict/dictionarysettings.cpp
+++ b/gui/dict/dictionarysettings.cpp
@@ -1,0 +1,67 @@
+#include "dictionarysettings.h"
+
+#include <QSettings>
+#include <QGlobalStatic>
+#include <clientsettings.h>
+#include <defaultvalues.h>
+
+Q_GLOBAL_STATIC(DictionarySettingsInstance, uniqueInstance)
+
+namespace {
+const char* DICTIONARY_NAME_PATH = "Dictionary/Command";
+const char* DICTIONARY_ARGS_PATH = "Dictionary/Arguments";
+}
+
+
+DictionarySettings* DictionarySettings::getInstance() {
+    return uniqueInstance;
+}
+
+DictionarySettings::DictionarySettings() {
+    clientSettings = ClientSettings::getInstance();
+    this->init();
+}
+
+DictionarySettings::~DictionarySettings() {    
+    delete settings;
+}
+
+
+void DictionarySettings::init() {    
+    settings = new QSettings(clientSettings->profilePath() + "dict.ini", QSettings::IniFormat);
+}
+
+void DictionarySettings::reInit() {
+    delete settings;
+    this->init();
+}
+
+void DictionarySettings::setParameter(QString name, QVariant value) {
+    settings->setValue(name, value);
+}
+
+QVariant DictionarySettings::getParameter(QString name, QVariant defaultValue) const {
+    return settings->value(name, defaultValue);
+}
+
+
+QString DictionarySettings::getDictCommand() const {
+    return settings->value(DICTIONARY_NAME_PATH,
+        DEFAULT_DICT_CMD).value<QString>();
+}
+
+QString DictionarySettings::getDictArguments() const {
+    return settings->value(DICTIONARY_ARGS_PATH,
+        DEFAULT_DICT_ARGS).value<QString>();
+}
+
+DictionarySettings& DictionarySettings::setDictCommand(const QString &cmd) {
+    settings->setValue(DICTIONARY_NAME_PATH, cmd);
+    return *this;
+}
+
+DictionarySettings& DictionarySettings::setDictArguments(const QString& args) {
+    settings->setValue(DICTIONARY_ARGS_PATH, args);
+    return *this;
+}
+

--- a/gui/dict/dictionarysettings.cpp
+++ b/gui/dict/dictionarysettings.cpp
@@ -17,51 +17,29 @@ DictionarySettings* DictionarySettings::getInstance() {
     return uniqueInstance;
 }
 
-DictionarySettings::DictionarySettings() {
-    clientSettings = ClientSettings::getInstance();
-    this->init();
+DictionarySettings::DictionarySettings() : clientSettings(ClientSettings::getInstance()) {
 }
 
-DictionarySettings::~DictionarySettings() {    
-    delete settings;
+DictionarySettings::~DictionarySettings() {
 }
-
-
-void DictionarySettings::init() {    
-    settings = new QSettings(clientSettings->profilePath() + "dict.ini", QSettings::IniFormat);
-}
-
-void DictionarySettings::reInit() {
-    delete settings;
-    this->init();
-}
-
-void DictionarySettings::setParameter(QString name, QVariant value) {
-    settings->setValue(name, value);
-}
-
-QVariant DictionarySettings::getParameter(QString name, QVariant defaultValue) const {
-    return settings->value(name, defaultValue);
-}
-
 
 QString DictionarySettings::getDictCommand() const {
-    return settings->value(DICTIONARY_NAME_PATH,
-        DEFAULT_DICT_CMD).value<QString>();
+    return clientSettings->getParameter(DICTIONARY_NAME_PATH,
+                                        DEFAULT_DICT_CMD).toString();
 }
 
 QString DictionarySettings::getDictArguments() const {
-    return settings->value(DICTIONARY_ARGS_PATH,
-        DEFAULT_DICT_ARGS).value<QString>();
+    return clientSettings->getParameter(DICTIONARY_ARGS_PATH,
+                                        DEFAULT_DICT_ARGS).toString();
 }
 
 DictionarySettings& DictionarySettings::setDictCommand(const QString &cmd) {
-    settings->setValue(DICTIONARY_NAME_PATH, cmd);
+    clientSettings->setParameter(DICTIONARY_NAME_PATH, cmd);
     return *this;
 }
 
 DictionarySettings& DictionarySettings::setDictArguments(const QString& args) {
-    settings->setValue(DICTIONARY_ARGS_PATH, args);
+    clientSettings->setParameter(DICTIONARY_ARGS_PATH, args);
     return *this;
 }
 

--- a/gui/dict/dictionarysettings.h
+++ b/gui/dict/dictionarysettings.h
@@ -28,10 +28,6 @@ public:
 private:
     explicit DictionarySettings();
 
-    void init();
-
-    QSettings* settings;
-
     ClientSettings* clientSettings;
 };
 

--- a/gui/dict/dictionarysettings.h
+++ b/gui/dict/dictionarysettings.h
@@ -14,16 +14,18 @@ public:
  
     ~DictionarySettings();
 
-    void reInit();
-
     void setParameter(QString name, QVariant value);
     QVariant getParameter(QString name, QVariant defaultValue) const;
 
     QString getDictCommand() const;
     QString getDictArguments() const;
+    bool getDoubleClickEnabled() const;
+    Qt::KeyboardModifier getDoubleClickModifier() const;
 
     DictionarySettings& setDictCommand(const QString& cmd);
     DictionarySettings& setDictArguments(const QString& args);
+    DictionarySettings& setDoubleClickEnabled(bool enabled);
+    DictionarySettings& setDoubleClickModifier(Qt::KeyboardModifier modifier);
     
 private:
     explicit DictionarySettings();

--- a/gui/dict/dictionarysettings.h
+++ b/gui/dict/dictionarysettings.h
@@ -1,0 +1,42 @@
+#ifndef DICTIONARYSETTINGS_H
+#define DICTIONARYSETTINGS_H
+
+#include <QVariant>
+
+class QSettings;
+class ClientSettings;
+
+class DictionarySettings {
+    friend class DictionarySettingsInstance;
+
+public:
+    static DictionarySettings* getInstance();
+ 
+    ~DictionarySettings();
+
+    void reInit();
+
+    void setParameter(QString name, QVariant value);
+    QVariant getParameter(QString name, QVariant defaultValue) const;
+
+    QString getDictCommand() const;
+    QString getDictArguments() const;
+
+    DictionarySettings& setDictCommand(const QString& cmd);
+    DictionarySettings& setDictArguments(const QString& args);
+    
+private:
+    explicit DictionarySettings();
+
+    void init();
+
+    QSettings* settings;
+
+    ClientSettings* clientSettings;
+};
+
+
+class DictionarySettingsInstance : public DictionarySettings {
+};
+
+#endif // DICTIONARYSETTINGS_H

--- a/gui/gamewindow.cpp
+++ b/gui/gamewindow.cpp
@@ -84,6 +84,12 @@ void GameWindow::buildContextMenu() {
 
     menu->addSeparator();
 
+    
+    lookupDictAct = new QAction(tr("&Lookup in Dictionary\t"), this);
+    menu->addAction(lookupDictAct);
+    lookupDictAct->setEnabled(false);
+    connect(lookupDictAct, SIGNAL(triggered()), this, SLOT(lookupInDictionary()));
+    
     copyAct = new QAction(tr("&Copy\t"), this);
     menu->addAction(copyAct);
     copyAct->setEnabled(false);
@@ -127,6 +133,17 @@ void GameWindow::resizeEvent(QResizeEvent *event) {
 
 void GameWindow::enableCopy(bool enabled) {
     copyAct->setEnabled(enabled);
+    lookupDictAct->setEnabled(enabled);
+}
+
+void GameWindow::lookupInDictionary() {
+  QTextCursor textCursor = this->textCursor();
+  if (textCursor.hasSelection()) {
+    QString word = textCursor.selectedText().trimmed().toLower();
+    if (word.size()) {
+        mainWindow->getDictionaryService()->translate(word);
+    }
+  }
 }
 
 void GameWindow::copySelected() {
@@ -139,6 +156,7 @@ void GameWindow::copySelected() {
 
 GameWindow::~GameWindow() {        
     delete appearanceAct;
+    delete lookupDictAct;
     delete copyAct;
     delete selectAct;
     delete clearAct;

--- a/gui/gamewindow.cpp
+++ b/gui/gamewindow.cpp
@@ -4,6 +4,7 @@ GameWindow::GameWindow(QWidget *parent) : QPlainTextEdit(parent) {
     mainWindow = (MainWindow*)parent;       
     windowFacade = mainWindow->getWindowFacade();
     settings = GeneralSettings::getInstance();
+    dictionarySettings = DictionarySettings::getInstance();
     snapshot = new Snapshot(this);
 
     this->setObjectName(WINDOW_TITLE_MAIN);
@@ -131,10 +132,20 @@ void GameWindow::resizeEvent(QResizeEvent *event) {
     QPlainTextEdit::resizeEvent(event);
 }
 
+void GameWindow::mouseDoubleClickEvent(QMouseEvent *e) {
+    QPlainTextEdit::mouseDoubleClickEvent(e);
+    if (dictionarySettings->getDoubleClickEnabled() &&
+        e->button() == Qt::LeftButton &&
+        e->modifiers() == dictionarySettings->getDoubleClickModifier()) {
+        lookupInDictionary();
+    }
+}
+
 void GameWindow::enableCopy(bool enabled) {
     copyAct->setEnabled(enabled);
     lookupDictAct->setEnabled(enabled);
 }
+
 
 void GameWindow::lookupInDictionary() {
   QTextCursor textCursor = this->textCursor();

--- a/gui/gamewindow.h
+++ b/gui/gamewindow.h
@@ -53,6 +53,7 @@ private:
     Snapshot* snapshot;
 
     QAction* appearanceAct;
+    QAction* lookupDictAct;
     QAction* copyAct;
     QAction* selectAct;
     QAction* clearAct;
@@ -65,6 +66,7 @@ private:
 signals:    
 
 private slots:
+    void lookupInDictionary();
     void copySelected();
     void enableCopy(bool);
     void saveAsHtml();

--- a/gui/gamewindow.h
+++ b/gui/gamewindow.h
@@ -8,6 +8,7 @@
 #include <mainwindow.h>
 #include <windowfacade.h>
 #include <generalsettings.h>
+#include <dict/dictionarysettings.h>
 #include <defaultvalues.h>
 #include <windowinterface.h>
 #include <snapshot.h>
@@ -17,6 +18,7 @@ class MainWindow;
 class WindowFacade;
 class Snapshot;
 class Compass;
+class DictionarySettings;
 
 class GameWindow : public QPlainTextEdit, public WindowInterface {
     Q_OBJECT
@@ -40,7 +42,8 @@ public:
 private:
     void contextMenuEvent(QContextMenuEvent* event);
     void resizeEvent(QResizeEvent* event);
-
+    void mouseDoubleClickEvent(QMouseEvent *e);
+    
     void loadSettings();
     void buildContextMenu();
 
@@ -49,6 +52,7 @@ private:
     MainWindow* mainWindow;
     WindowFacade* windowFacade;
     GeneralSettings* settings;
+    DictionarySettings* dictionarySettings;
 
     Snapshot* snapshot;
 

--- a/gui/genericwindow.cpp
+++ b/gui/genericwindow.cpp
@@ -3,6 +3,7 @@
 GenericWindow::GenericWindow(QString title, QWidget *parent) : QPlainTextEdit(parent) {
     mainWindow = (MainWindow*)parent;
     settings = GeneralSettings::getInstance();
+    dictionarySettings = DictionarySettings::getInstance();
     wm = mainWindow->getWindowFacade();
     snapshot = new Snapshot(this);
 
@@ -163,6 +164,15 @@ void GenericWindow::contextMenuEvent(QContextMenuEvent* event) {
     QPoint point = event->globalPos();
     point.rx()--; point.ry()--;
     menu->exec(point);
+}
+
+void GenericWindow::mouseDoubleClickEvent(QMouseEvent *e) {
+    QPlainTextEdit::mouseDoubleClickEvent(e);
+    if (dictionarySettings->getDoubleClickEnabled() &&
+        e->button() == Qt::LeftButton &&
+        e->modifiers() == dictionarySettings->getDoubleClickModifier()) {
+        lookupInDictionary();
+    }
 }
 
 void GenericWindow::enableCopy(bool enabled) {

--- a/gui/genericwindow.cpp
+++ b/gui/genericwindow.cpp
@@ -86,6 +86,11 @@ void GenericWindow::buildContextMenu() {
     menu->addAction(appearanceAct);
     connect(appearanceAct, SIGNAL(triggered()), this, SLOT(changeAppearance()));
 
+    lookupDictAct = new QAction(tr("&Lookup in Dictionary\t"), this);
+    menu->addAction(lookupDictAct);
+    lookupDictAct->setEnabled(false);
+    connect(lookupDictAct, SIGNAL(triggered()), this, SLOT(lookupInDictionary()));
+
     menu->addSeparator();
 
     fontAct = new QAction(tr("&" WINDOW_FONT_SET "\t"), this);
@@ -162,6 +167,17 @@ void GenericWindow::contextMenuEvent(QContextMenuEvent* event) {
 
 void GenericWindow::enableCopy(bool enabled) {
     copyAct->setEnabled(enabled);
+    lookupDictAct->setEnabled(enabled);    
+}
+
+void GenericWindow::lookupInDictionary() {
+  QTextCursor textCursor = this->textCursor();
+  if (textCursor.hasSelection()) {
+    QString word = textCursor.selectedText().trimmed().toLower();
+    if (word.size()) {
+        mainWindow->getDictionaryService()->translate(word);
+    }
+  }
 }
 
 void GenericWindow::copySelected() {

--- a/gui/genericwindow.h
+++ b/gui/genericwindow.h
@@ -6,6 +6,7 @@
 #include <QMouseEvent>
 
 #include <generalsettings.h>
+#include <dict/dictionarysettings.h>
 #include <mainwindow.h>
 #include <windowinterface.h>
 #include <snapshot.h>
@@ -38,11 +39,13 @@ public:
 
 private:
     void contextMenuEvent(QContextMenuEvent* event);
+    void mouseDoubleClickEvent(QMouseEvent *e);    
     void buildContextMenu();    
     void loadSettings();
 
     MainWindow* mainWindow;
     GeneralSettings* settings;
+    DictionarySettings* dictionarySettings;
     WindowFacade* wm;
     QString windowId;
 

--- a/gui/genericwindow.h
+++ b/gui/genericwindow.h
@@ -49,6 +49,7 @@ private:
     Snapshot* snapshot;
 
     QAction* appearanceAct;
+    QAction* lookupDictAct;    
     QAction* copyAct;
     QAction* selectAct;
     QAction* saveAct;
@@ -63,6 +64,7 @@ private:
 signals:
 
 private slots:
+    void lookupInDictionary();    
     void copySelected();
     void enableCopy(bool);
     void saveAsHtml();

--- a/gui/gui.pro
+++ b/gui/gui.pro
@@ -30,6 +30,7 @@ include(window/window.pri)
 include(custom/custom.pri)
 include(audio/audio.pri)
 include(toolbar/toolbar.pri)
+include(dict/dict.pri)
 
 APP_NAME = Frostbite
 

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -143,8 +143,15 @@ void MainWindow::loadClient() {
 
     scriptApiServer = new ScriptApiServer(this);
 
+    dictionaryService = new DictionaryService(this);
+    
     connect(ui->menuBar, SIGNAL(triggered(QAction*)), menuHandler, SLOT(menuTriggered(QAction*)));
     connect(ui->menuBar, SIGNAL(hovered(QAction*)), menuHandler, SLOT(menuHovered(QAction*)));
+
+    connect(dictionaryService, SIGNAL(translationFinished(QString)),
+            windowFacade->getDictionaryWindow(), SLOT(write(QString)));
+    connect(dictionaryService, SIGNAL(translationFailed(QString)),
+            windowFacade->getDictionaryWindow(), SLOT(write(QString)));
 }
 
 WindowFacade* MainWindow::getWindowFacade() {
@@ -169,6 +176,10 @@ CommandLine* MainWindow::getCommandLine() {
 
 ScriptService* MainWindow::getScriptService() {
     return scriptService;
+}
+
+DictionaryService* MainWindow::getDictionaryService() {
+    return dictionaryService;
 }
 
 TimerBar* MainWindow::getTimerBar() {

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -16,6 +16,7 @@
 #include <generalsettings.h>
 #include <tray.h>
 #include <scriptapiserver.h>
+#include <dict/dictionaryservice.h>
 //#include <compass/compassview.h>
 
 #include "cleanlooks/qcleanlooksstyle.h"
@@ -114,6 +115,7 @@ public:
     TcpClient* getTcpClient();
     CommandLine* getCommandLine();
     ScriptService* getScriptService();
+    DictionaryService* getDictionaryService();
     TimerBar* getTimerBar();
     Tray* getTray();
 
@@ -128,6 +130,7 @@ private:
     MenuHandler* menuHandler;
     ScriptService* scriptService;
     ScriptApiServer* scriptApiServer;
+    DictionaryService* dictionaryService;
 
     Tray* tray;
     TimerBar* timerBar;

--- a/gui/mainwindow.ui
+++ b/gui/mainwindow.ui
@@ -197,6 +197,7 @@ QTabBar {
     <addaction name="actionAppearance"/>
     <addaction name="actionSubstitute"/>
     <addaction name="actionMacros"/>
+    <addaction name="actionDictionary"/>
    </widget>
    <widget class="QMenu" name="menuWindow">
     <property name="title">
@@ -368,6 +369,17 @@ QTabBar {
    </property>
    <property name="text">
     <string>Window Appearance</string>
+   </property>
+   <property name="menuRole">
+    <enum>QAction::PreferencesRole</enum>
+   </property>
+  </action>
+  <action name="actionDictionary">
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Dictionary</string>
    </property>
    <property name="menuRole">
     <enum>QAction::PreferencesRole</enum>

--- a/gui/menuhandler.cpp
+++ b/gui/menuhandler.cpp
@@ -1,4 +1,5 @@
 #include "menuhandler.h"
+#include "gui/dict/dictionarydialog.h"
 
 MenuHandler::MenuHandler(QObject *parent) : QObject(parent) {
     mainWindow = (MainWindow*)parent;
@@ -13,6 +14,8 @@ MenuHandler::MenuHandler(QObject *parent) : QObject(parent) {
     aboutDialog = new AboutDialog(qobject_cast<QWidget *>(parent));
     scriptEditDialog = new ScriptEditDialog(qobject_cast<QWidget *>(parent));    
     volumeControlDialog = new VolumeControlDialog(qobject_cast<QWidget *>(parent));
+    dictionaryDialog = new DictionaryDialog(qobject_cast<QWidget *>(parent));
+    
     profileAddDialog = new ProfileAddDialog();
 
     windowFacade = mainWindow->getWindowFacade();
@@ -68,6 +71,8 @@ void MenuHandler::menuTriggered(QAction* action) {
         alterDialog->show();
     } else if (action->objectName() == "actionAppearance") {
         appearanceDialog->show();
+    } else if(action->objectName() == "actionDictionary") {
+        dictionaryDialog->show();
     } else if(action->objectName() == "actionExit") {
         mainWindow->close();
     } else if(action->objectName() == "actionAbout") {

--- a/gui/menuhandler.h
+++ b/gui/menuhandler.h
@@ -17,6 +17,7 @@
 #include <clientsettings.h>
 #include <scriptsettingsdialog.h>
 #include <audio/volumecontroldialog.h>
+#include <dict/dictionarydialog.h>
 
 class ConnectWizard;
 class MainWindow;
@@ -28,6 +29,7 @@ class ScriptEditDialog;
 class ProfileAddDialog;
 class ScriptSettingsDialog;
 class VolumeControlDialog;
+class DictionaryDialog;
 
 #define USER_GUIDE_URL "http://matoom.github.com/frostbite"
 
@@ -56,6 +58,7 @@ private:
     ProfileAddDialog* profileAddDialog;
     WindowFacade* windowFacade;
     VolumeControlDialog* volumeControlDialog;
+    DictionaryDialog* dictionaryDialog;
 
     QMenu* profilesMenu;
     QAction* action;

--- a/gui/window/dictionarywindow.cpp
+++ b/gui/window/dictionarywindow.cpp
@@ -1,0 +1,37 @@
+#include "dictionarywindow.h"
+
+DictionaryWindow::DictionaryWindow(QObject *parent) : QObject(parent) {
+    mainWindow = (MainWindow*)parent;
+    windowFacade = (WindowFacade*)mainWindow->getWindowFacade();
+    visible = false;
+
+    dock = GenericWindowFactory(parent).createWindow(DOCK_TITLE_DICTIONARY);
+    window = (GenericWindow*)dock->widget();
+    window->setAppend(false);
+
+    writer = new WindowWriterThread(mainWindow, window);
+
+    mainWindow->addDockWidgetMainWindow(Qt::RightDockWidgetArea, dock);
+
+    connect(dock, SIGNAL(visibilityChanged(bool)), this, SLOT(setVisible(bool)));
+    connect(windowFacade, SIGNAL(updateWindowSettings()), writer, SLOT(updateSettings()));
+}
+
+void DictionaryWindow::setVisible(bool visible) {
+    dock->setWindowTitle(DOCK_TITLE_DICTIONARY);
+    this->visible = visible;
+}
+
+QDockWidget* DictionaryWindow::getDockWidget() {
+    return dock;
+}
+
+void DictionaryWindow::write(QString text) {
+    dock->setWindowTitle(visible ? DOCK_TITLE_DICTIONARY : DOCK_TITLE_DICTIONARY " *");
+    writer->addText(text);
+    if(!writer->isRunning()) writer->start();
+}
+
+DictionaryWindow::~DictionaryWindow() {
+    delete writer;
+}

--- a/gui/window/dictionarywindow.h
+++ b/gui/window/dictionarywindow.h
@@ -1,0 +1,32 @@
+#ifndef DICTIONARYWINDOW_H
+#define DICTIONARYWINDOW_H
+
+#include <QObject>
+#include <mainwindow.h>
+#include <windowfacade.h>
+
+class DictionaryWindow : public QObject {
+    Q_OBJECT
+
+public:
+    DictionaryWindow(QObject *parent = 0);
+    ~DictionaryWindow();
+
+    QDockWidget* getDockWidget();
+
+private:
+    MainWindow* mainWindow;
+    WindowFacade* windowFacade;
+    GenericWindow* window;
+    QDockWidget* dock;
+    WindowWriterThread* writer;
+
+    bool visible;
+
+public slots:
+    void setVisible(bool);
+    void write(QString text);
+
+};
+
+#endif // DICTIONARYWINDOW_H

--- a/gui/window/window.pri
+++ b/gui/window/window.pri
@@ -9,7 +9,8 @@ HEADERS += \
     $$PWD/roomwindow.h \
     $$PWD/expwindow.h \
     $$PWD/groupwindow.h \
-    $$PWD/combatwindow.h
+    $$PWD/combatwindow.h \
+    $$PWD/dictionarywindow.h
 
 SOURCES += \
     $$PWD/spellwindow.cpp \
@@ -22,4 +23,5 @@ SOURCES += \
     $$PWD/roomwindow.cpp \
     $$PWD/expwindow.cpp \
     $$PWD/groupwindow.cpp \
-    $$PWD/combatwindow.cpp
+    $$PWD/combatwindow.cpp \
+    $$PWD/dictionarywindow.cpp

--- a/gui/windowfacade.cpp
+++ b/gui/windowfacade.cpp
@@ -2,7 +2,7 @@
 
 QStringList WindowFacade::staticWindows = QStringList() << "inv" << "familiar" << "thoughts"
     << "logons" << "death" << "assess" << "conversation" << "whispers" << "talk" << "experience"
-    << "group" << "atmospherics" << "ooc" << "room" << "percWindow" << "chatter";
+    << "group" << "atmospherics" << "ooc" << "room" << "percWindow" << "chatter" << "dictionary";
 
 WindowFacade::WindowFacade(QObject *parent) : QObject(parent) {
     mainWindow = (MainWindow*)parent;    
@@ -228,6 +228,9 @@ void WindowFacade::loadWindows() {
     combatWindow = new CombatWindow(mainWindow);
     dockWindows << combatWindow->getDockWidget();
 
+    dictionaryWindow = new DictionaryWindow(mainWindow);
+    dockWindows << dictionaryWindow->getDockWidget();
+
     compassView = new CompassView(mainWindow);
     compassView->paint(compass);
 
@@ -242,11 +245,13 @@ void WindowFacade::loadWindows() {
         mainWindow->tabifyDockWidget(familiarWindow->getDockWidget(), spellWindow->getDockWidget());        
         mainWindow->tabifyDockWidget(spellWindow->getDockWidget(), atmosphericsWindow->getDockWidget());
         mainWindow->tabifyDockWidget(atmosphericsWindow->getDockWidget(), combatWindow->getDockWidget());
+        mainWindow->tabifyDockWidget(combatWindow->getDockWidget(), dictionaryWindow->getDockWidget());
 
         groupWindow->getDockWidget()->close();
         combatWindow->getDockWidget()->close();
         atmosphericsWindow->getDockWidget()->close();
         familiarWindow->getDockWidget()->close();
+        dictionaryWindow->getDockWidget()->close();
     }
 
     this->updateWindowStyle();
@@ -313,6 +318,11 @@ GroupWindow* WindowFacade::getGroupWindow() {
 CombatWindow* WindowFacade::getCombatWindow() {
     return this->combatWindow;
 }
+
+DictionaryWindow* WindowFacade::getDictionaryWindow() {
+    return this->dictionaryWindow;
+}
+
 
 MapFacade* WindowFacade::getMapFacade() {
     return this->mapFacade;

--- a/gui/windowfacade.h
+++ b/gui/windowfacade.h
@@ -36,6 +36,7 @@
 #include <window/atmosphericswindow.h>
 #include <window/groupwindow.h>
 #include <window/combatwindow.h>
+#include <window/dictionarywindow.h>
 
 #include <QGraphicsPixmapItem>
 #include <QGraphicsProxyWidget>
@@ -62,6 +63,7 @@ class SpellWindow;
 class AtmosphericsWindow;
 class GroupWindow;
 class CombatWindow;
+class DictionaryWindow;
 
 typedef QList<QString> DirectionsList;
 typedef QMap<QString, QString> GridItems;
@@ -105,7 +107,8 @@ public:
     AtmosphericsWindow* getAtmosphericsWindow();
     GroupWindow* getGroupWindow();
     CombatWindow* getCombatWindow();
-
+    DictionaryWindow* getDictionaryWindow();
+    
     QStringList getWindowNames();
 
     MapFacade* getMapFacade();    
@@ -159,6 +162,7 @@ private:
     AtmosphericsWindow* atmosphericsWindow;
     GroupWindow* groupWindow;
     CombatWindow* combatWindow;
+    DictionaryWindow* dictionaryWindow;
 
     QList<QDockWidget*> dockWindows;
     QHash<QString, QDockWidget*> streamWindows;


### PR DESCRIPTION
This pull request implements the support for command-line dictionaries (i.e. *dict* on GNU/Linux). It adds settings for the path to dictionary program and optional command line arguments (i.e. particular dictionary to use), new dock window for dictionary output, new context menu option for Game screen to _Lookup in dictionary_. 