### PR TITLE
Handle clickable URLs in the main window.

### DIFF
--- a/gui/gamewindow.cpp
+++ b/gui/gamewindow.cpp
@@ -1,4 +1,5 @@
 #include "gamewindow.h"
+#include <QDesktopServices>
 
 GameWindow::GameWindow(QWidget *parent) : QPlainTextEdit(parent) {
     mainWindow = (MainWindow*)parent;       
@@ -140,6 +141,22 @@ void GameWindow::mouseDoubleClickEvent(QMouseEvent *e) {
         lookupInDictionary();
     }
 }
+
+void GameWindow::mousePressEvent(QMouseEvent *e) {
+    clickedAnchor = (e->button() == Qt::LeftButton) ?
+        anchorAt(e->pos()) : QString();
+    QPlainTextEdit::mousePressEvent(e);
+}
+
+void GameWindow::mouseReleaseEvent(QMouseEvent *e) {
+    if (e->button() == Qt::LeftButton &&
+        !clickedAnchor.isEmpty() &&
+        anchorAt(e->pos()) == clickedAnchor) {
+        QDesktopServices::openUrl(QUrl(clickedAnchor, QUrl::TolerantMode));
+    }
+    QPlainTextEdit::mouseReleaseEvent(e);
+}
+
 
 void GameWindow::enableCopy(bool enabled) {
     copyAct->setEnabled(enabled);

--- a/gui/gamewindow.h
+++ b/gui/gamewindow.h
@@ -43,6 +43,8 @@ private:
     void contextMenuEvent(QContextMenuEvent* event);
     void resizeEvent(QResizeEvent* event);
     void mouseDoubleClickEvent(QMouseEvent *e);
+    void mousePressEvent(QMouseEvent *e);
+    void mouseReleaseEvent(QMouseEvent *e);
     
     void loadSettings();
     void buildContextMenu();
@@ -67,6 +69,7 @@ private:
     bool _append;
     bool _stream;
 
+    QString clickedAnchor;
 signals:    
 
 private slots:


### PR DESCRIPTION
The mouse click event on URLs in a GameWindow should
open them in external browser. It simplifies new player
experience.