### PR TITLE
Reduce CPU usage by ScriptWriterThread

### DIFF
--- a/gui/arrivalslogger.cpp
+++ b/gui/arrivalslogger.cpp
@@ -4,21 +4,10 @@ ArrivalsLogger::ArrivalsLogger(QObject*) {
 }
 
 void ArrivalsLogger::addText(QString text) {
-    mMutex.lock();
-    dataQueue.enqueue(text);
-    mMutex.unlock();
+    Parent::addData(text);
 }
 
-void ArrivalsLogger::run() {
-    while(!dataQueue.isEmpty()) {
-        mMutex.lock();
-        localData = dataQueue.dequeue();
-        mMutex.unlock();
-
-        logger()->info(localData);
-    }
-}
-
-ArrivalsLogger::~ArrivalsLogger() {
+void ArrivalsLogger::onProcess(const QString& text) {
+    logger()->info(text);    
 }
 

--- a/gui/arrivalslogger.h
+++ b/gui/arrivalslogger.h
@@ -1,27 +1,24 @@
 #ifndef ARRIVALSLOGGER_H
 #define ARRIVALSLOGGER_H
 
-#include <QObject>
-#include <QQueue>
-#include <QMutex>
-#include <QThread>
+#include <QString>
+#include <QRegExp>
 
 #include <log4qt/logger.h>
 
-class ArrivalsLogger : public QThread {
+#include "workqueuethread.h"
+
+class ArrivalsLogger : public WorkQueueThread<QString> {
     Q_OBJECT
     LOG4QT_DECLARE_QCLASS_LOGGER
 
+    using Parent = WorkQueueThread<QString>;
 public:
     explicit ArrivalsLogger(QObject *parent = 0);
-    ~ArrivalsLogger();
-
-    virtual void run();
-
-private:
-    QQueue<QString> dataQueue;
-    QMutex mMutex;
-    QString localData;
+    ~ArrivalsLogger() = default;
+    
+protected:
+    void onProcess(const QString& text);
 
 signals:
 

--- a/gui/authlogger.cpp
+++ b/gui/authlogger.cpp
@@ -4,19 +4,10 @@ AuthLogger::AuthLogger(QObject*) {
 }
 
 void AuthLogger::addText(QString text) {
-    mMutex.lock();
-    dataQueue.enqueue(text);
-    mMutex.unlock();
+    Parent::addData(text);
 }
 
-void AuthLogger::run() {
-    while(!dataQueue.isEmpty()) {
-        mMutex.lock();
-        localData = dataQueue.dequeue();
-        mMutex.unlock();
-        logger()->info(localData);
-    }
+void AuthLogger::onProcess(const QString &text) {
+  logger()->info(text);
 }
 
-AuthLogger::~AuthLogger() {
-}

--- a/gui/authlogger.h
+++ b/gui/authlogger.h
@@ -1,28 +1,25 @@
 #ifndef AUTHLOGGER_H
 #define AUTHLOGGER_H
 
-#include <QObject>
-#include <QQueue>
-#include <QMutex>
-#include <QThread>
+#include <QString>
+#include <QRegExp>
 
 #include <log4qt/logger.h>
 
-class AuthLogger: public QThread {
+#include "workqueuethread.h"
+
+class AuthLogger: public WorkQueueThread<QString> {
     Q_OBJECT
     LOG4QT_DECLARE_QCLASS_LOGGER
-
+    
+    using Parent = WorkQueueThread<QString>;
 public:
     explicit AuthLogger(QObject *parent = 0);
-    ~AuthLogger();
+    ~AuthLogger() = default;
 
-    virtual void run();
-
-private:
-    QQueue<QString> dataQueue;
-    QMutex mMutex;
-    QString localData;
-
+protected:
+    void onProcess(const QString& text) override;
+    
 signals:
 
 public slots:

--- a/gui/concurrentqueue.h
+++ b/gui/concurrentqueue.h
@@ -45,8 +45,8 @@ public:
     }
     
 private:
-    QWaitCondition queueCondition;
     mutable QMutex mutex;
+    QWaitCondition queueCondition;
     QQueue<T> queue;
     bool shouldStop = false;
 };

--- a/gui/concurrentqueue.h
+++ b/gui/concurrentqueue.h
@@ -1,0 +1,54 @@
+#ifndef CONCURRENT_QUEUE_H
+#define CONCURRENT_QUEUE_H
+
+#include <QQueue>
+#include <QMutex>
+#include <QMutexLocker>
+#include <QWaitCondition>
+
+template <typename T>
+class ConcurrentQueue {
+public:
+    ConcurrentQueue() = default;
+    ~ConcurrentQueue() = default;
+
+    bool empty() const { 
+        QMutexLocker lock(&mutex);
+        return queue.isEmpty();
+    }
+    
+    void push(T const& data) {
+        mutex.lock();
+        const auto wasEmpty = queue.isEmpty();
+        queue.enqueue(data);
+        mutex.unlock();
+        // signal if the data was added to the empty queue
+        if (wasEmpty) {
+            queueCondition.wakeOne();
+        }
+    }
+
+    bool waitAndPop(T& data) {
+        QMutexLocker lock(&mutex);
+        while(queue.isEmpty()) {
+            queueCondition.wait(&mutex);
+            if (shouldStop) return false;
+        }
+        data = queue.dequeue();
+        return true;
+    }
+
+    void stop() {
+        QMutexLocker lock(&mutex);
+        shouldStop = true;
+        queueCondition.wakeOne();
+    }
+    
+private:
+    QWaitCondition queueCondition;
+    mutable QMutex mutex;
+    QQueue<T> queue;
+    bool shouldStop = false;
+};
+
+#endif // CONCURRENT_QUEUE_H

--- a/gui/concurrentqueue.h
+++ b/gui/concurrentqueue.h
@@ -39,8 +39,9 @@ public:
     }
 
     void stop() {
-        QMutexLocker lock(&mutex);
+        mutex.lock();
         shouldStop = true;
+        mutex.unlock();
         queueCondition.wakeOne();
     }
     

--- a/gui/conversationslogger.cpp
+++ b/gui/conversationslogger.cpp
@@ -1,28 +1,15 @@
 #include "conversationslogger.h"
+#include "textutils.h"
 
 ConversationsLogger::ConversationsLogger(QObject*) {
     rxRemoveTags.setPattern("<[^>]*>");
 }
 
 void ConversationsLogger::addText(QString text) {
-    mMutex.lock();
-    dataQueue.enqueue(text);
-    mMutex.unlock();
-}
-
-void ConversationsLogger::run() {
-    while(!dataQueue.isEmpty()) {
-        mMutex.lock();
-        localData = dataQueue.dequeue();
-        mMutex.unlock();
-        log(localData);
-    }
+    Parent::addData(text);
 }
 
 void ConversationsLogger::log(QString logText) {
     TextUtils::htmlToPlain(logText);
     logger()->info(logText.remove(rxRemoveTags));
-}
-
-ConversationsLogger::~ConversationsLogger() {
 }

--- a/gui/conversationslogger.h
+++ b/gui/conversationslogger.h
@@ -1,30 +1,29 @@
 #ifndef CONVERSATIONSLOGGER_H
 #define CONVERSATIONSLOGGER_H
 
-#include <QObject>
-#include <QQueue>
-#include <QMutex>
-#include <QThread>
+#include <QString>
 #include <QRegExp>
 
 #include <log4qt/logger.h>
-#include <textutils.h>
 
-class ConversationsLogger : public QThread {
+#include "workqueuethread.h"
+
+class ConversationsLogger : public WorkQueueThread<QString> {
     Q_OBJECT
     LOG4QT_DECLARE_QCLASS_LOGGER
-
+    
+    using Parent = WorkQueueThread<QString>;
 public:
     explicit ConversationsLogger(QObject *parent = 0);
-    ~ConversationsLogger();
+    ~ConversationsLogger() = default;
 
-    virtual void run();
+protected:
+    void onProcess(const QString& text) override {
+        log(text);
+    }
 
 private:
-    QQueue<QString> dataQueue;
-    QMutex mMutex;
     QRegExp rxRemoveTags;
-    QString localData;
 
     void log(QString);
 

--- a/gui/deathslogger.cpp
+++ b/gui/deathslogger.cpp
@@ -4,20 +4,9 @@ DeathsLogger::DeathsLogger(QObject*) {
 }
 
 void DeathsLogger::addText(QString text) {
-    mMutex.lock();
-    dataQueue.enqueue(text);
-    mMutex.unlock();
+    Parent::addData(text);
 }
 
-void DeathsLogger::run() {
-    while(!dataQueue.isEmpty()) {
-        mMutex.lock();
-        localData = dataQueue.dequeue();
-        mMutex.unlock();
-        logger()->info(localData);
-    }
-}
-
-DeathsLogger::~DeathsLogger() {
-
+void DeathsLogger::onProcess(const QString& text) {
+    logger()->info(text);
 }

--- a/gui/deathslogger.h
+++ b/gui/deathslogger.h
@@ -1,30 +1,24 @@
 #ifndef DEATHSLOGGER_H
 #define DEATHSLOGGER_H
 
-#include <QObject>
-#include <QQueue>
-#include <QMutex>
-#include <QThread>
+#include <QString>
 
 #include <log4qt/logger.h>
 
-class DeathsLogger : public QThread {
+#include "workqueuethread.h"
+
+class DeathsLogger : public WorkQueueThread<QString> {
     Q_OBJECT
     LOG4QT_DECLARE_QCLASS_LOGGER
-
+    
+    using Parent = WorkQueueThread<QString>;
 public:
     explicit DeathsLogger(QObject *parent = 0);
-    ~DeathsLogger();
+    ~DeathsLogger() = default;
 
-    virtual void run();
-
-private:
-    QQueue<QString> dataQueue;
-    QMutex mMutex;
-    QString localData;
-
-signals:
-
+protected:
+    void onProcess(const QString& text) override;
+    
 public slots:
     void addText(QString);
 

--- a/gui/debuglogger.cpp
+++ b/gui/debuglogger.cpp
@@ -4,24 +4,9 @@ DebugLogger::DebugLogger(QObject*) {
 }
 
 void DebugLogger::addText(QString text) {
-    mMutex.lock();
-    dataQueue.enqueue(text);
-    mMutex.unlock();
+    Parent::addData(text);
 }
 
-void DebugLogger::run() {
-    while(!dataQueue.isEmpty()) {
-        mMutex.lock();
-        localData = dataQueue.dequeue();
-        mMutex.unlock();
-        logger()->info(localData);
-    }
-}
-
-DebugLogger::~DebugLogger() {   
-    if(!this->wait(1000)) {
-        qWarning("Thread deadlock detected, terminating thread.");
-        this->terminate();
-        this->wait();
-    }
+void DebugLogger::onProcess(const QString& text) {
+    logger()->info(text);
 }

--- a/gui/debuglogger.h
+++ b/gui/debuglogger.h
@@ -1,30 +1,24 @@
 #ifndef DEBUGLOGGER_H
 #define DEBUGLOGGER_H
 
-#include <QObject>
-#include <QQueue>
-#include <QMutex>
-#include <QThread>
+#include <QString>
 
 #include <log4qt/logger.h>
 
-class DebugLogger: public QThread {
+#include "workqueuethread.h"
+
+class DebugLogger: public WorkQueueThread<QString> {
     Q_OBJECT
     LOG4QT_DECLARE_QCLASS_LOGGER
 
+    using Parent = WorkQueueThread<QString>;
 public:
     explicit DebugLogger(QObject *parent = 0);
-    ~DebugLogger();
-
-    virtual void run();
-
-private:
-    QQueue<QString> dataQueue;
-    QMutex mMutex;
-    QString localData;
-
-signals:
-
+    ~DebugLogger() = default;
+    
+protected:
+    void onProcess(const QString& text) override;
+    
 public slots:
     void addText(QString);
 

--- a/gui/gridwriterthread.h
+++ b/gui/gridwriterthread.h
@@ -1,12 +1,9 @@
 #ifndef GRIDHIGHLIGHTERTHREAD_H
 #define GRIDHIGHLIGHTERTHREAD_H
 
-#include <QObject>
-#include <QThread>
-#include <QQueue>
-#include <QMutex>
+#include <QString>
 #include <QMap>
-#include "concurrentqueue.h"
+#include "workqueuethread.h"
 
 class Highlighter;
 class GridWindow;
@@ -20,18 +17,17 @@ struct GridEntry {
 
 typedef QMap<QString, QString> GridItems;
 
-class GridWriterThread : public QThread {
+class GridWriterThread : public WorkQueueThread<GridEntry> {
     Q_OBJECT
-
+    using Parent = WorkQueueThread<GridEntry>;
 public:
     explicit GridWriterThread(QObject *parent, GridWindow* window);
-    ~GridWriterThread();
+    ~GridWriterThread() = default;
 
-    virtual void run();
-
+protected:
+    void onProcess(const GridEntry& data) override;
+    
 private:
-    ConcurrentQueue<GridEntry> dataQueue;
-
     Highlighter* highlighter;
     Alter* alter;
 

--- a/gui/gridwriterthread.h
+++ b/gui/gridwriterthread.h
@@ -6,7 +6,8 @@
 #include <QQueue>
 #include <QMutex>
 #include <QMap>
- 
+#include "concurrentqueue.h"
+
 class Highlighter;
 class GridWindow;
 class MainWindow;
@@ -29,24 +30,20 @@ public:
     virtual void run();
 
 private:
-    QQueue<GridEntry> dataQueue;
+    ConcurrentQueue<GridEntry> dataQueue;
 
     Highlighter* highlighter;
     Alter* alter;
 
     MainWindow* mainWindow;
-    QMutex mMutex;
     bool append;
     QRegExp rxRemoveTags;
-    GridEntry localData;
     QMap<QString, QString> highlightedItems;
 
     GridWindow* window;
 
     void write(GridEntry);
     QString process(QString text, QString win);
-
-    bool exit;
 
 public slots:
     void addItem(QString, QString);

--- a/gui/gui.pro
+++ b/gui/gui.pro
@@ -155,7 +155,9 @@ HEADERS  += mainwindow.h \
     scriptsettingsdialog.h \
     compass.h \
     genieutils.h \
-    hyperlinkservice.h
+    hyperlinkservice.h \
+    concurrentqueue.h \
+    workqueuethread.h \
 
 FORMS    += mainwindow.ui \
     macrodialog.ui \

--- a/gui/mainlogger.h
+++ b/gui/mainlogger.h
@@ -1,40 +1,37 @@
 #ifndef MAINLOGGER_H
 #define MAINLOGGER_H
 
-#include <QObject>
-#include <QQueue>
 #include <QDebug>
-#include <QMutex>
 #include <QRegExp>
-#include <QThread>
 
 #include <log4qt/logger.h>
 
-class Alter;
+#include "workqueuethread.h"
 
-class MainLogger : public QThread {
-    Q_OBJECT
-    LOG4QT_DECLARE_QCLASS_LOGGER
+
+class Alter;
 
 struct LogEntry {
     QString text;
     char type;
 };
 
+class MainLogger : public WorkQueueThread<LogEntry> {
+    Q_OBJECT
+    LOG4QT_DECLARE_QCLASS_LOGGER
+    
+    using Parent = WorkQueueThread<LogEntry>;
 public:
     explicit MainLogger(QObject *parent = 0);
-    ~MainLogger();
-
-    virtual void run();
+    ~MainLogger() = default;
 
     static const char COMMAND = 'c';
     static const char PROMPT = 'p';
-
+protected:
+    void onProcess(const LogEntry& entry) override;
+    
 private:
-    QQueue<LogEntry> dataQueue;
-    QMutex mMutex;
     QRegExp rxRemoveTags;
-    LogEntry localData;
     Alter* alter;
 
     void log(LogEntry);

--- a/gui/scriptservice.cpp
+++ b/gui/scriptservice.cpp
@@ -100,7 +100,7 @@ void ScriptService::writeGameWindow(QByteArray command) {
 
 void ScriptService::writeScriptText(QByteArray text) {
     if(!text.isEmpty() && this->isScriptActive()) {
-        scriptWriter->addText(text.data());
+        scriptWriter->addData(text.data());
     }
 }
 

--- a/gui/scriptwriterthread.cpp
+++ b/gui/scriptwriterthread.cpp
@@ -11,22 +11,7 @@ ScriptWriterThread::ScriptWriterThread(QObject *parent) {
             scriptService, SLOT(writeOutgoingMessage(QByteArray)));
 }
 
-void ScriptWriterThread::addText(QString text) {
-    dataQueue.push(text);
-}
-
-void ScriptWriterThread::run() {
-    while(!this->isInterruptionRequested()) {
-        QString localData;
-        if (dataQueue.waitAndPop(localData)) {
-            process(localData);
-        } else {
-            break;
-        }
-    }
-}
-
-void ScriptWriterThread::process(const QString& lines) {
+void ScriptWriterThread::onProcess(const QString& lines) {
     foreach (QString line, lines.split("\n")) {
         line = line.remove(rxRemoveTags);
         TextUtils::htmlToPlain(line);
@@ -34,12 +19,3 @@ void ScriptWriterThread::process(const QString& lines) {
     }
 }
 
-ScriptWriterThread::~ScriptWriterThread() {
-    this->requestInterruption();
-    dataQueue.stop();
-    if(!this->wait(1000)) {
-        qWarning("Thread deadlock detected, terminating thread.");
-        this->terminate();
-        this->wait();
-    }
-}

--- a/gui/scriptwriterthread.cpp
+++ b/gui/scriptwriterthread.cpp
@@ -16,7 +16,7 @@ void ScriptWriterThread::addText(QString text) {
 }
 
 void ScriptWriterThread::run() {
-    while(true) {
+    while(!this->isInterruptionRequested()) {
         QString localData;
         if (dataQueue.waitAndPop(localData)) {
             process(localData);
@@ -26,7 +26,7 @@ void ScriptWriterThread::run() {
     }
 }
 
-void ScriptWriterThread::process(QString lines) {
+void ScriptWriterThread::process(const QString& lines) {
     foreach (QString line, lines.split("\n")) {
         line = line.remove(rxRemoveTags);
         TextUtils::htmlToPlain(line);
@@ -35,6 +35,7 @@ void ScriptWriterThread::process(QString lines) {
 }
 
 ScriptWriterThread::~ScriptWriterThread() {
+    this->requestInterruption();
     dataQueue.stop();
     if(!this->wait(1000)) {
         qWarning("Thread deadlock detected, terminating thread.");

--- a/gui/scriptwriterthread.h
+++ b/gui/scriptwriterthread.h
@@ -5,6 +5,7 @@
 #include <QObject>
 #include <QQueue>
 #include <QMutex>
+#include "concurrentqueue.h"
 
 class ScriptService;
 
@@ -18,14 +19,9 @@ public:
     virtual void run();
 
 private:
-    QQueue<QString> dataQueue;
+    ConcurrentQueue<QString> dataQueue;
     ScriptService* scriptService;
-    QMutex mMutex;
-    QString localData;
-
     QRegExp rxRemoveTags;
-
-    bool exit;
 
     void process(QString data);
     

--- a/gui/scriptwriterthread.h
+++ b/gui/scriptwriterthread.h
@@ -1,36 +1,29 @@
 #ifndef SCRIPTWRITERTHREAD_H
 #define SCRIPTWRITERTHREAD_H
 
-#include <QThread>
-#include <QObject>
-#include <QQueue>
-#include <QMutex>
-#include "concurrentqueue.h"
+#include <QRegExp>
+#include <QString>
+#include <QByteArray>
+
+#include "workqueuethread.h"
 
 class ScriptService;
 
-class ScriptWriterThread : public QThread {
+class ScriptWriterThread : public WorkQueueThread<QString> {
     Q_OBJECT
 
 public:
     explicit ScriptWriterThread(QObject *parent = 0);
-    ~ScriptWriterThread();
+    ~ScriptWriterThread() = default;
 
-    virtual void run();
+    void onProcess(const QString& data) override;
 
 private:
-    ConcurrentQueue<QString> dataQueue;
     ScriptService* scriptService;
     QRegExp rxRemoveTags;
-
-    void process(const QString& data);
     
 signals:
-    void writeText(QByteArray);
-
-public slots:
-    void addText(QString text);
-    
+    void writeText(QByteArray);    
 };
 
 #endif // SCRIPTWRITERTHREAD_H

--- a/gui/scriptwriterthread.h
+++ b/gui/scriptwriterthread.h
@@ -23,7 +23,7 @@ private:
     ScriptService* scriptService;
     QRegExp rxRemoveTags;
 
-    void process(QString data);
+    void process(const QString& data);
     
 signals:
     void writeText(QByteArray);

--- a/gui/thoughtslogger.cpp
+++ b/gui/thoughtslogger.cpp
@@ -6,24 +6,10 @@ ThoughtsLogger::ThoughtsLogger(QObject*) {
 }
 
 void ThoughtsLogger::addText(QString text) {
-    mMutex.lock();
-    dataQueue.enqueue(text);
-    mMutex.unlock();
-}
-
-void ThoughtsLogger::run() {
-    while(!dataQueue.isEmpty()) {
-        mMutex.lock();
-        localData = dataQueue.dequeue();
-        mMutex.unlock();
-        log(localData);
-    }
+    Parent::addData(text);
 }
 
 void ThoughtsLogger::log(QString logText) {
     TextUtils::htmlToPlain(logText);
     logger()->info(logText.remove(rxRemoveTags));
-}
-
-ThoughtsLogger::~ThoughtsLogger() {
 }

--- a/gui/thoughtslogger.h
+++ b/gui/thoughtslogger.h
@@ -1,29 +1,30 @@
 #ifndef THOUGHTSLOGGER_H
 #define THOUGHTSLOGGER_H
 
-#include <QObject>
-#include <QQueue>
-#include <QMutex>
+#include <QString>
 #include <QRegExp>
-#include <QThread>
 
 #include <log4qt/logger.h>
 
-class ThoughtsLogger : public QThread {
+#include "workqueuethread.h"
+
+class ThoughtsLogger : public WorkQueueThread<QString> {
     Q_OBJECT
     LOG4QT_DECLARE_QCLASS_LOGGER
 
+    using Parent = WorkQueueThread<QString>;
 public:
     explicit ThoughtsLogger(QObject *parent = 0);
-    ~ThoughtsLogger();
+    ~ThoughtsLogger() = default;
 
-    virtual void run();
+protected:
+    void onProcess(const QString& text) override {
+        log(text);
+    }
+    
 
 private:
-    QQueue<QString> dataQueue;
-    QMutex mMutex;
     QRegExp rxRemoveTags;
-    QString localData;
 
     void log(QString);
 

--- a/gui/windowfacade.cpp
+++ b/gui/windowfacade.cpp
@@ -458,7 +458,6 @@ void WindowFacade::removeStreamWindow(QString id) {
     if(!streamWindows.contains(id)) return;
 
     WindowWriterThread* writer = streamWriters.value(id);
-    writer->requestInterruption();
     writer->wait();
     delete writer;
     streamWriters.remove(id);
@@ -503,13 +502,9 @@ void WindowFacade::unlockWindows() {
 
 WindowFacade::~WindowFacade() {
     delete compass;
-
     foreach(WindowWriterThread* writer, streamWriters) {
-        writer->terminate();
         delete writer;
     }
-
-    mainWriter->terminate();
     delete mainWriter;
 
     foreach(QDockWidget* dock, streamWindows) {

--- a/gui/windowwriterthread.h
+++ b/gui/windowwriterthread.h
@@ -1,12 +1,10 @@
 #ifndef WINDOWWRITERTHREAD_H
 #define WINDOWWRITERTHREAD_H
 
-#include <QObject>
-#include <QThread>
+#include <QString>
 #include <QPlainTextEdit>
-#include <QQueue>
-#include <QMutex>
-#include "concurrentqueue.h"
+
+#include "workqueuethread.h"
 
 class Highlighter;
 class Alter;
@@ -14,17 +12,16 @@ class WindowInterface;
 class MainWindow;
 class WindowInterface;
 
-class WindowWriterThread : public QThread {
+class WindowWriterThread : public WorkQueueThread<QString> {
     Q_OBJECT
-
+    using Parent = WorkQueueThread<QString>;
 public:
     WindowWriterThread(QObject *parent, WindowInterface* window);
-    ~WindowWriterThread();
-
-    virtual void run();
+    ~WindowWriterThread() = default;
+protected:
+    void onProcess(const QString& data) override;
 
 private:
-    ConcurrentQueue<QString> dataQueue;
     QPlainTextEdit* textEdit;
 
     Highlighter* highlighter;
@@ -34,7 +31,6 @@ private:
     QRegExp rxRemoveTags;
     WindowInterface *window;
 
-    void write(QString);
     QString process(QString text, QString win);
 
     void setText(QString);

--- a/gui/windowwriterthread.h
+++ b/gui/windowwriterthread.h
@@ -6,6 +6,7 @@
 #include <QPlainTextEdit>
 #include <QQueue>
 #include <QMutex>
+#include "concurrentqueue.h"
 
 class Highlighter;
 class Alter;
@@ -23,16 +24,14 @@ public:
     virtual void run();
 
 private:
-    QQueue<QString> dataQueue;
+    ConcurrentQueue<QString> dataQueue;
     QPlainTextEdit* textEdit;
 
     Highlighter* highlighter;
     Alter* alter;
 
     MainWindow* mainWindow;
-    QMutex mMutex;
     QRegExp rxRemoveTags;
-    QString localData;
     WindowInterface *window;
 
     void write(QString);

--- a/gui/workqueuethread.h
+++ b/gui/workqueuethread.h
@@ -1,0 +1,49 @@
+#ifndef WORKQUEUETHREAD_H
+#define WORKQUEUETHREAD_H
+
+#include <QThread>
+#include "concurrentqueue.h"
+
+template <typename T>
+class WorkQueueThread : public QThread {
+public:
+    WorkQueueThread(QObject *parent = nullptr) : QThread(parent) {}
+    
+    ~WorkQueueThread() {
+        stop();
+        if(!this->wait(1000)) {
+            qWarning("Thread deadlock detected, terminating thread.");
+            this->terminate();
+            this->wait();
+        }        
+    }
+
+    void stop() {
+        this->requestInterruption();
+        dataQueue.stop();
+    }
+    
+    void addData(const T& data) {
+        dataQueue.push(data);        
+    }
+    
+protected:
+    virtual void run() {
+        while (!this->isInterruptionRequested()) {
+            T localData;
+            if (dataQueue.waitAndPop(localData)) {
+                onProcess(localData);
+            } else {
+                break;
+            }
+        }
+    }
+    
+    virtual void onProcess(const T& data) = 0;
+private:
+    ConcurrentQueue<T> dataQueue;
+
+
+};
+
+#endif // WORKQUEUETHREAD_H

--- a/gui/xml/xmlparserthread.cpp
+++ b/gui/xml/xmlparserthread.cpp
@@ -88,19 +88,9 @@ void XmlParserThread::updateHighlighterSettings() {
 }
 
 void XmlParserThread::addData(QByteArray buffer) {
-    dataQueue.push(buffer);
+    Parent::addData(buffer);
 }
 
-void XmlParserThread::run() {
-    while(!this->isInterruptionRequested()) {
-        QByteArray localData;
-        if (dataQueue.waitAndPop(localData)) {
-            cache(localData);
-        } else {
-            break;
-        }
-    }
-}
 
 bool XmlParserThread::isCmgr() {
     bool result = cmgr;
@@ -123,7 +113,7 @@ void XmlParserThread::flushStream() {
 }
 
 /* cache streams */
-void XmlParserThread::cache(QByteArray data) {
+void XmlParserThread::onProcess(const QByteArray& data) {
     QString cache = QString::fromLocal8Bit(data);
 
     int lastPush = cache.lastIndexOf("<pushStream");
@@ -723,15 +713,4 @@ QString XmlParserThread::wrapRoot(QString data) {
 
 QString XmlParserThread::wrapCdata(QString data) {
     return "<![CDATA[" + data + "]]>";
-}
-
-XmlParserThread::~XmlParserThread() {
-    this->requestInterruption();
-    dataQueue.stop();
-    if(!this->wait(1000)) {
-        qWarning("Thread deadlock detected, terminating thread.");
-        this->terminate();
-        this->wait();
-    }
-    delete highlighter;
 }

--- a/gui/xml/xmlparserthread.h
+++ b/gui/xml/xmlparserthread.h
@@ -10,6 +10,9 @@
 #include <QFile>
 #include <QHash>
 #include <QtXml/QDomNode>
+#include <QAtomicInt>
+
+#include "concurrentqueue.h"
 
 class MainWindow;
 class WindowFacade;
@@ -34,8 +37,7 @@ public:
     void process(QString);
 
 private:
-    QQueue<QByteArray> dataQueue;
-    QMutex mMutex;
+    ConcurrentQueue<QByteArray> dataQueue;
 
     void cache(QByteArray data);    
 
@@ -65,7 +67,6 @@ private:
 
     QHash<QString, QVariant> scheduled;
 
-    bool exit;
     bool bold;
     bool initRoundtime;
     bool initCastTime;
@@ -74,7 +75,7 @@ private:
     QString streamCache;
 
     bool mono;
-    bool cmgr;
+    QAtomicInt cmgr;
 
     bool pushStream;
 
@@ -108,7 +109,6 @@ private:
 
     QRegExp rxDmg;
 
-    QByteArray localData;
 
 signals:
     void updateConversationsWindow(QString);

--- a/gui/xml/xmlparserthread.h
+++ b/gui/xml/xmlparserthread.h
@@ -1,18 +1,16 @@
 #ifndef XMLPARSERTHREAD_H
 #define XMLPARSERTHREAD_H
 
-#include <QObject>
-#include <QThread>
-#include <QMutex>
 #include <QDateTime>
-#include <QQueue>
 #include <QByteArray>
 #include <QFile>
 #include <QHash>
+#include <QString>
+#include <QVariant>
 #include <QtXml/QDomNode>
 #include <QAtomicInt>
 
-#include "concurrentqueue.h"
+#include "workqueuethread.h"
 
 class MainWindow;
 class WindowFacade;
@@ -24,22 +22,19 @@ class VitalsBar;
 
 typedef QList<QString> DirectionsList;
 
-class XmlParserThread : public QThread {
+class XmlParserThread : public WorkQueueThread<QByteArray> {
     Q_OBJECT
-
+    using Parent = WorkQueueThread<QByteArray>;
 public:
     explicit XmlParserThread(QObject *parent = 0);
-    ~XmlParserThread();
+    ~XmlParserThread() = default;
 
-    virtual void run();
     bool isCmgr();
 
     void process(QString);
-
+protected:
+    void onProcess(const QByteArray& data) override;
 private:
-    ConcurrentQueue<QByteArray> dataQueue;
-
-    void cache(QByteArray data);    
 
     bool filterPlainText(QDomElement, QDomNode);
     bool filterDataTags(QDomElement, QDomNode);


### PR DESCRIPTION
Current implementation of the ScriptWriterThread
makes it consume up to 2% CPU in idle mode on my PC.
Most likely the usleep is too small so overhead of
using mutex and switching contexts actually increase
load on CPU.
The new implementation adds a generic single-consumer
concurrent queue, which is now used by script writer,
which avoids this problem by using condition variable.

I've tested it with my script and it still works. Please have a look if you have any ideas or if you can test if the scripting still works as it should.