### PR TITLE
Clear anchor after clicking on a link.

### DIFF
--- a/gui/gamewindow.cpp
+++ b/gui/gamewindow.cpp
@@ -162,9 +162,11 @@ void GameWindow::mousePressEvent(QMouseEvent *e) {
 
 void GameWindow::mouseReleaseEvent(QMouseEvent *e) {
     if (e->button() == Qt::LeftButton &&
-        !clickedAnchor.isEmpty() &&
-        anchorAt(e->pos()) == clickedAnchor) {
-        QDesktopServices::openUrl(QUrl(clickedAnchor, QUrl::TolerantMode));
+        !clickedAnchor.isEmpty()) {
+        if (anchorAt(e->pos()) == clickedAnchor) {
+            QDesktopServices::openUrl(QUrl(clickedAnchor, QUrl::TolerantMode));
+        }
+        clickedAnchor.clear();
     }
     QPlainTextEdit::mouseReleaseEvent(e);
 }


### PR DESCRIPTION
I  thought it will fix the bug with hyperlink active after click, but it is not. See pull#82.