### PR TITLE
Improved import highlights from Genie

### DIFF
--- a/gui/commandline.cpp
+++ b/gui/commandline.cpp
@@ -26,7 +26,7 @@ CommandLine::CommandLine(QWidget *parent) : QLineEdit(parent) {
     keyboardFilter = new KeyboardFilter(this);
     settings = GeneralSettings::getInstance();
 
-    genieUtils = new GenieUtils(mainWindow);
+    genieUtils = mainWindow->getGenieUtils();
 
     historyCounter = -1;
 

--- a/gui/genieutils.cpp
+++ b/gui/genieutils.cpp
@@ -51,7 +51,7 @@ bool GenieUtils::importFile(QString fileName) {
 void GenieUtils::addRegexHighlight(const GenieUtils::GenieHighlight& highlight) {
     HighlightSettings* settings = HighlightSettings::getInstance();
 
-    QBitArray opts {};
+    QBitArray opts(5);
     opts.setBit(1, 1);
     if (highlight.type == "beginswith") {
         opts.setBit(0, 1);

--- a/gui/genieutils.cpp
+++ b/gui/genieutils.cpp
@@ -51,8 +51,12 @@ bool GenieUtils::importFile(QString fileName) {
 void GenieUtils::addRegexHighlight(const GenieUtils::GenieHighlight& highlight) {
     HighlightSettings* settings = HighlightSettings::getInstance();
 
-    QBitArray opts = QBitArray(5);
-    opts.setBit(1, 1);
+    QBitArray opts{};
+    if (highlight.type == "regexp") {
+        opts.setBit(1,1);
+    } else if(highlight.type == "beginswith") {
+        opts.setBit(2, 1);
+    }
 
     HighlightSettingsEntry entry
         = HighlightSettingsEntry(0,

--- a/gui/genieutils.cpp
+++ b/gui/genieutils.cpp
@@ -51,10 +51,10 @@ bool GenieUtils::importFile(QString fileName) {
 void GenieUtils::addRegexHighlight(const GenieUtils::GenieHighlight& highlight) {
     HighlightSettings* settings = HighlightSettings::getInstance();
 
-    QBitArray opts{};
-    if (highlight.type == "regexp") {
-        opts.setBit(1,1);
-    } else if(highlight.type == "beginswith") {
+    QBitArray opts {};
+    opts.setBit(1, 1);
+    if (highlight.type == "beginswith") {
+        opts.setBit(0, 1);
         opts.setBit(2, 1);
     }
 

--- a/gui/genieutils.cpp
+++ b/gui/genieutils.cpp
@@ -1,38 +1,88 @@
 #include "genieutils.h"
+
+#include <QRegularExpression>
+#include <QRegularExpressionMatch>
+#include <QColor>
+#include <QFile>
+#include <QTextStream>
+#include <QString>
+
 #include "mainwindow.h"
 #include "text/highlight/highlightsettingsentry.h"
 #include "text/highlight/highlightsettings.h"
 #include "textutils.h"
 
-GenieUtils::GenieUtils(QObject *parent) : QObject(parent) {
-    mainWindow = (MainWindow*)qobject_cast<QObject *>(parent);
+#include <QtDebug>
 
-    connect(this, SIGNAL(reloadSettings()), mainWindow, SLOT(reloadSettings()));
+GenieUtils::GenieUtils(QObject *parent) : QObject(parent) {
 }
 
 void GenieUtils::importHighlights(QString imports) {
     QStringList entries = imports.split("#highlight");
     for(QString entry : entries) {
-        QStringList values = entry.split("} {");
-        if(values.size() > 3) {
-            this->addRegexHighlight(TextUtils::stripBraces(values.at(2)), TextUtils::stripBraces(values.at(1)));
+        // restore prefix
+        entry.prepend("highlight ");
+        auto hl = parseHighlight(entry);
+        // parse at least until regexp
+        if (!hl.regexp.isEmpty()) {
+            this->addRegexHighlight(hl);
         }
     }
     this->commitSettings();
 }
 
-void GenieUtils::addRegexHighlight(QString pattern, QString color) {
+bool GenieUtils::importFile(QString fileName) {
+    QFile file(fileName);
+    if (!file.open(QIODevice::ReadOnly)) {
+        qFatal("Unable to find file");
+        return false;
+    }
+    QTextStream in(&file);
+    for (QString line = in.readLine(); !line.isEmpty(); line = in.readLine()) {
+        auto hl = parseHighlight(line);
+        // parse at least until regexp
+        if (!hl.regexp.isEmpty()) {
+            this->addRegexHighlight(hl);
+        }
+    }
+    return true;
+}
+
+void GenieUtils::addRegexHighlight(const GenieUtils::GenieHighlight& highlight) {
     HighlightSettings* settings = HighlightSettings::getInstance();
 
     QBitArray opts = QBitArray(5);
     opts.setBit(1, 1);
 
-    HighlightSettingsEntry entry = HighlightSettingsEntry(0, pattern, "General",
-                                                          QColor(color), QColor(), false, "", false, 0, "", opts);
+    HighlightSettingsEntry entry
+        = HighlightSettingsEntry(0,
+                                 highlight.regexp,
+                                 highlight.category.isEmpty() ? "General" : highlight.category,
+                                 highlight.color,
+                                 QColor(),
+                                 !highlight.sound.isEmpty(),
+                                 highlight.sound,
+                                 false, 0, "", opts);
 
     settings->addParameter("TextHighlight", entry);
 }
 
 void GenieUtils::commitSettings() {
     emit reloadSettings();
+}
+
+GenieUtils::GenieHighlight GenieUtils::parseHighlight(const QString &line) {
+    GenieHighlight highlight;
+    if (line.startsWith("#highlight")) {
+        static const QRegularExpression re("{(.*?)}");
+        auto matchIterator = re.globalMatch(line);
+        if (matchIterator.hasNext()) {
+            int pos = 0;
+            while (matchIterator.hasNext()) {
+                highlight.fieldFromPosition(pos, matchIterator.next().captured(1));
+                ++pos;
+            }
+        }
+    }
+    return highlight;
 }

--- a/gui/genieutils.h
+++ b/gui/genieutils.h
@@ -2,6 +2,7 @@
 #define GENIEUTILS_H
 
 #include <QObject>
+#include <QColor>
 
 class MainWindow;
 
@@ -12,9 +13,41 @@ public:
     explicit GenieUtils(QObject *parent = 0);
 
     void importHighlights(QString imports);
+    bool importFile(QString fileName);
 
 private:
-    void addRegexHighlight(QString pattern, QString color);
+    struct GenieHighlight {
+        QString type;
+        QColor color;
+        QString regexp;
+        QString category;
+        QString sound;
+
+        void fieldFromPosition(int pos, const QString &text) {
+            switch (pos) {
+            case 0:
+                type = text;
+                break;
+            case 1:
+                color.setNamedColor(text);
+                break;
+            case 2:
+                regexp = text;
+                break;
+            case 3:
+                category = text;
+                break;
+            case 4:
+                sound = text;
+                break;
+            default:
+                break;
+            }
+        }
+    };
+    
+    static GenieHighlight parseHighlight(const QString &line);
+    void addRegexHighlight(const GenieHighlight& highlight);
     void commitSettings();
 
     MainWindow *mainWindow;

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -25,6 +25,7 @@
 #include "compass/compassview.h"
 #include "macrosettings.h"
 #include "hyperlinkservice.h"
+#include "genieutils.h"
 
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWindow) {
     ui->setupUi(this);
@@ -70,6 +71,10 @@ void MainWindow::appSetup() {
 
     // load tray
     tray = new Tray(this);
+
+    // Create Genie utils
+    genieUtils = new GenieUtils(this);
+    connect(genieUtils, SIGNAL(reloadSettings()), this, SLOT(reloadSettings()));
 }
 
 void MainWindow::toggleFullScreen() {
@@ -212,8 +217,12 @@ TimerBar* MainWindow::getTimerBar() {
     return this->timerBar;
 }
 
-Tray* MainWindow::getTray() {
+Tray *MainWindow::getTray() {
     return this->tray;
+}
+
+GenieUtils* MainWindow::getGenieUtils() {
+    return this->genieUtils;
 }
 
 void MainWindow::addWidgetMainLayout(QWidget* widget) {

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -35,7 +35,7 @@ class ScriptApiServer;
 class DictionaryService;
 class ClientSettings;
 class HyperlinkService;
-
+class GenieUtils;
 
 class MainWindow : public QMainWindow {
     Q_OBJECT
@@ -105,6 +105,7 @@ public:
     DictionaryService* getDictionaryService();
     TimerBar* getTimerBar();
     Tray* getTray();
+    GenieUtils* getGenieUtils();
 
 private:
     Ui::MainWindow* ui;
@@ -119,6 +120,7 @@ private:
     ScriptApiServer* scriptApiServer;
     DictionaryService* dictionaryService;
     HyperlinkService* hyperlinkService;
+    GenieUtils* genieUtils;
     QMenu* commandMenu;
 
     Tray* tray;

--- a/gui/text/highlight/highlightdialog.cpp
+++ b/gui/text/highlight/highlightdialog.cpp
@@ -72,8 +72,12 @@ QPushButton* HighlightDialog::getTextAddButton() {
     return ui->tAdd;
 }
 
-QPushButton* HighlightDialog::getTextRemoveButton() {
+QPushButton *HighlightDialog::getTextRemoveButton() {
     return ui->tRemove;
+}
+
+QPushButton* HighlightDialog::getTextImportGenieButton() {
+    return ui->tImportGenie;
 }
 
 QListWidget* HighlightDialog::getTextList() {

--- a/gui/text/highlight/highlightdialog.h
+++ b/gui/text/highlight/highlightdialog.h
@@ -56,6 +56,7 @@ public:
     QComboBox* getTextHighlightGroup();
     QComboBox* getTextHighlightSortBy();
     QLineEdit* getTextHighlightFilter();
+    QPushButton* getTextImportGenieButton();
 
     /* alert tab items */
     QGroupBox* getBleedingGroup();

--- a/gui/text/highlight/highlightdialog.ui
+++ b/gui/text/highlight/highlightdialog.ui
@@ -281,6 +281,16 @@
             </widget>
            </item>
            <item>
+            <widget class="QPushButton" name="tImportGenie">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="text">
+              <string>Import from Genie...</string>
+             </property>
+            </widget>
+           </item>
+           <item>
             <spacer name="horizontalSpacer_5">
              <property name="orientation">
               <enum>Qt::Horizontal</enum>

--- a/gui/text/highlight/highlighter.h
+++ b/gui/text/highlight/highlighter.h
@@ -2,17 +2,25 @@
 #define HIGHLIGHTER_H
 
 #include <QObject>
+#include <QRegExp>
+#include <vector>
 
 #include "text/highlight/highlightsettingsentry.h"
 
 class HighlightSettings;
 class MainWindow;
-class HighlightSettingsEntry;
 class AudioPlayer;
 
 class Highlighter : public QObject {
     Q_OBJECT
-
+public:
+    struct Entry {
+        HighlightSettingsEntry entry;
+        QString htmlValue;
+        QString startTag;
+        QString endTag;
+        QRegExp re;
+    };
 public:
     explicit Highlighter(QObject *parent = 0);
     ~Highlighter();
@@ -30,15 +38,15 @@ private:
 
     bool healthAlert;    
 
-    int highlightText(HighlightSettingsEntry, QString&, int, QString);
-    void highlightAlert(HighlightSettingsEntry);
-    void highlightTimer(HighlightSettingsEntry);
+    int highlightText(const Entry&, QString&, int, int);
+    void highlightAlert(const HighlightSettingsEntry&);
+    void highlightTimer(const HighlightSettingsEntry&);
 
-    static QString createCommand(const QString& text, const QString& command);
-
+    static Entry createEntryFromHighlight(const HighlightSettingsEntry& highlight);
+    
     Qt::CaseSensitivity matchCase(bool);
 
-    QList<HighlightSettingsEntry> highlightList;
+    std::vector<Entry> highlightList;
 
 signals:
     void playAudio(QString);

--- a/gui/text/highlight/highlighttexttab.cpp
+++ b/gui/text/highlight/highlighttexttab.cpp
@@ -1,5 +1,8 @@
 #include "highlighttexttab.h"
 
+#include <QFileDialog>
+#include <QMessageBox>
+
 #include "text/highlight/highlightdialog.h"
 #include "text/highlight/highlightadddialog.h"
 #include "text/highlight/highlighteditdialog.h"
@@ -10,6 +13,7 @@
 #include "defaultvalues.h"
 #include "custom/contextmenu.h"
 #include "mainwindow.h"
+#include "genieutils.h"
 
 HighlightTextTab::HighlightTextTab(QObject *parent) : QObject(parent) {    
     highlightSettings = HighlightSettings::getInstance();
@@ -22,7 +26,8 @@ HighlightTextTab::HighlightTextTab(QObject *parent) : QObject(parent) {
 
     addButton = highlightDialog->getTextAddButton();
     applyButton = highlightDialog->getApplyButton();
-    removeButton = highlightDialog->getTextRemoveButton();    
+    removeButton = highlightDialog->getTextRemoveButton();
+    importGenieButton = highlightDialog->getTextImportGenieButton();
     alertBox = highlightDialog->getTextAlertGroup();
     alertFileSelect = highlightDialog->getTextFileSelect();    
     entireRowCheck = highlightDialog->getTextEntireRow();
@@ -98,6 +103,9 @@ HighlightTextTab::HighlightTextTab(QObject *parent) : QObject(parent) {
             this, SLOT(listWidgetMenuRequested(const QPoint &)));
     connect(listWidget, SIGNAL(itemDoubleClicked(QListWidgetItem*)),
             this, SLOT(showEditDialog()));
+    
+    importGenieButton->setEnabled(true);
+    connect(importGenieButton, SIGNAL(clicked()), this, SLOT(importGenie()));
 }
 
 void HighlightTextTab::initContextMenu() {
@@ -600,6 +608,20 @@ void HighlightTextTab::showEditDialog() {
         HighlightSettingsEntry currentEntry = highlightList.at(currentId);
         highlightEditDialog->setEntry(currentEntry);
         highlightEditDialog->show();
+    }
+}
+
+void HighlightTextTab::importGenie() {
+    QString fileName = QFileDialog::getOpenFileName(highlightDialog, tr("Open Genie Highlights File"),
+                                                "",
+                                                tr("Config files (*.cfg)"));
+    if (!fileName.isEmpty()) {
+        if (!highlightDialog->getMainWindow()->getGenieUtils()->importFile(fileName)) {
+            QMessageBox::warning(highlightDialog, "Unable to open file", "Unable to open file with Genie highlights");
+        } else {
+            QMessageBox::information(highlightDialog, "Imported", "Import succeeded");
+            this->reloadHighlightList();
+        }
     }
 }
 

--- a/gui/text/highlight/highlighttexttab.h
+++ b/gui/text/highlight/highlighttexttab.h
@@ -49,6 +49,7 @@ private:
     QPushButton *addButton;
     QPushButton *applyButton;
     QPushButton *removeButton;
+    QPushButton *importGenieButton;
     QGroupBox *alertBox;
     QComboBox *alertFileSelect;
     QPushButton *playButton;
@@ -125,6 +126,7 @@ private slots:
     void playSound();
     void sortBySelected(int index);
     void filterList(const QString&);
+    void importGenie();
 
 public slots:
 


### PR DESCRIPTION
1) Added button in Highlights Text tab to import from Genie
2) Moved GenieUtils to MainWindow to be accessible from
   another classes but CommandLine. Main window also
   subscribes to its signal directly
3) Improved parsing of Genie highlights.cfg entries.

One thing I noticed though is after importing a lot of highlights (from http://elanthia.org/) the output is slow. Need to optimize the highlighting process.
UPDATE: I solved the performance drop in the commit 851de0c here.
On my measurements after importing all the highlights from elanthia.org (it is more than 200 entries) the original processing time for almost every text entry was up to 250 or more milliseconds. Measuring performance I found out the Highlighter class was guilty. I went through it and pre-calculated necessary tags, regexps etc all values are known on a highlight load time. It gave me instant performance increase, dropping the processing time to 1-2milliseconds.