### PR TITLE
Add Toggle Distraction Free mode

### DIFF
--- a/gui/compass/compassview.cpp
+++ b/gui/compass/compassview.cpp
@@ -44,6 +44,10 @@ void CompassView::setCompassVisible(bool visible) {
     }
 }
 
+bool CompassView::isVisible() const {
+    return visible;
+}
+
 void CompassView::resetCompass() {
     QPlainTextEdit* gameWindow = mainWindow->getWindowFacade()->getGameWindow();
     this->move(gameWindow->width() / 2, gameWindow->height() / 2);

--- a/gui/compass/compassview.h
+++ b/gui/compass/compassview.h
@@ -23,7 +23,7 @@ public:
 
     void paint(Compass*);
     void gameWindowResizeEvent(GameWindow*);
-
+    bool isVisible() const;
 private:
     bool locked;
     bool visible;

--- a/gui/gamewindow.cpp
+++ b/gui/gamewindow.cpp
@@ -124,6 +124,12 @@ void GameWindow::buildContextMenu() {
     clearAct = new QAction(tr("&Clear\t"), this);
     menu->addAction(clearAct);
     connect(clearAct, SIGNAL(triggered()), this, SLOT(clear()));
+
+    distractionFreeModeAct = new QAction(tr("Distraction free mode\t"), this);
+    distractionFreeModeAct->setCheckable(true);
+    distractionFreeModeAct->setChecked(false);
+    menu->addAction(distractionFreeModeAct);
+    connect(distractionFreeModeAct, SIGNAL(changed()), mainWindow, SLOT(toggleDistractionFreeMode()));
 }
 
 void GameWindow::changeAppearance() {

--- a/gui/gamewindow.h
+++ b/gui/gamewindow.h
@@ -60,6 +60,7 @@ private:
     QAction* selectAct;
     QAction* clearAct;
     QAction* saveAct;
+    QAction* distractionFreeModeAct;
     ContextMenu* menu;
 
     bool _append;

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1,6 +1,8 @@
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
 
+#include <QVBoxLayout>
+
 #include "cleanlooks/qcleanlooksstyle.h"
 
 #include "windowfacade.h"
@@ -80,6 +82,26 @@ void MainWindow::toggleMaximized() {
     setWindowState(Qt::WindowMaximized);
 }
 
+void MainWindow::toggleDistractionFreeMode() {
+    mainWidgetWindowFlags = mainWidget->windowFlags();
+    // if no parent in main widget, this means the main widget is
+    // maximized
+    if (mainWidget->parent()) { 
+        mainWidgetWindowFlags = mainWidget->windowFlags();
+        ui->mainLayout->removeWidget(mainWidget);
+        mainWidget->setParent(nullptr);
+        mainWidget->setWindowFlags(Qt::WindowStaysOnTopHint | Qt::FramelessWindowHint);
+        hide();
+        mainWidget->showFullScreen();
+    } else {        
+        mainWidget->setParent(this);
+        mainWidget->setWindowFlags(mainWidgetWindowFlags);
+        mainWidget->showNormal();
+        ui->mainLayout->addWidget(mainWidget);
+        show();
+    }
+}
+
 void MainWindow::updateScriptSettings() {
     scriptApiServer->reloadSettings();
 }
@@ -135,6 +157,14 @@ void MainWindow::initSettings() {
 }
 
 void MainWindow::loadClient() {
+    mainWidget = new QWidget(this);
+    mainWidget->setContentsMargins(0,0,0,0);
+    mainWidgetLayout = new QVBoxLayout(mainWidget);
+    mainWidgetLayout->setSpacing(0);
+    mainWidgetLayout->setContentsMargins(0,0,0,0);
+    ui->mainLayout->addWidget(mainWidget);
+
+    
     toolBar = new Toolbar(this);
     toolBar->loadToolbar();
 
@@ -157,7 +187,7 @@ void MainWindow::loadClient() {
     vitalsBar->add();
 
     cmdLine = new CommandLine(this);
-    ui->mainLayout->addWidget(cmdLine);
+    addWidgetMainLayout(cmdLine);
 
     scriptService = new ScriptService(this);
 
@@ -217,7 +247,7 @@ Tray* MainWindow::getTray() {
 }
 
 void MainWindow::addWidgetMainLayout(QWidget* widget) {
-    ui->mainLayout->addWidget(widget);
+    mainWidgetLayout->addWidget(widget);    
 }
 
 void MainWindow::addDockWidgetMainWindow(Qt::DockWidgetArea area, QDockWidget *dock) {

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -83,20 +83,28 @@ void MainWindow::toggleMaximized() {
 }
 
 void MainWindow::toggleDistractionFreeMode() {
-    mainWidgetWindowFlags = mainWidget->windowFlags();
     // if no parent in main widget, this means the main widget is
     // maximized
     if (mainWidget->parent()) { 
-        mainWidgetWindowFlags = mainWidget->windowFlags();
+        distractionFreeModeParams.mainWidgetWindowFlags = mainWidget->windowFlags();
+        distractionFreeModeParams.vitalsBarVisible = vitalsBar->isVisible();
+        distractionFreeModeParams.compassVisible = windowFacade->getCompassView()->isVisible();
+        // we want to hide both vitals bar and compass, but do not want to save this as a setting
+        vitalsBar->toggle(false, false);
+        windowFacade->getCompassView()->setCompassVisible(false);
         ui->mainLayout->removeWidget(mainWidget);
         mainWidget->setParent(nullptr);
         mainWidget->setWindowFlags(Qt::WindowStaysOnTopHint | Qt::FramelessWindowHint);
+        windowFacade->getGameWindow()->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
         hide();
         mainWidget->showFullScreen();
     } else {        
         mainWidget->setParent(this);
-        mainWidget->setWindowFlags(mainWidgetWindowFlags);
+        mainWidget->setWindowFlags(distractionFreeModeParams.mainWidgetWindowFlags);
         mainWidget->showNormal();
+        vitalsBar->toggle(distractionFreeModeParams.vitalsBarVisible, false);
+        windowFacade->getCompassView()->setCompassVisible(distractionFreeModeParams.compassVisible);
+        windowFacade->getGameWindow()->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
         ui->mainLayout->addWidget(mainWidget);
         show();
     }

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -111,7 +111,11 @@ private:
     Ui::MainWindow* ui;
     QWidget* mainWidget;
     QVBoxLayout* mainWidgetLayout;
-    Qt::WindowFlags mainWidgetWindowFlags;
+    struct {
+        Qt::WindowFlags mainWidgetWindowFlags;
+        bool vitalsBarVisible;
+        bool compassVisible;
+    } distractionFreeModeParams;
     WindowFacade* windowFacade;
     Toolbar* toolBar;
     TcpClient* tcpClient;

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -14,6 +14,7 @@ class QTextEdit;
 class QTextBrowser;
 class QTextLine;
 class QStringList;
+class QVBoxLayout;
 QT_END_NAMESPACE
 
 namespace Ui {
@@ -108,6 +109,9 @@ public:
 
 private:
     Ui::MainWindow* ui;
+    QWidget* mainWidget;
+    QVBoxLayout* mainWidgetLayout;
+    Qt::WindowFlags mainWidgetWindowFlags;
     WindowFacade* windowFacade;
     Toolbar* toolBar;
     TcpClient* tcpClient;
@@ -148,6 +152,7 @@ public slots:
     void reloadSettings();
     void actionCommand(const QString&);
     void actionCommands(const QStringList&);
+    void toggleDistractionFreeMode();    
 };
 
 #endif // MAINWINDOW_H

--- a/gui/vitalsbar.cpp
+++ b/gui/vitalsbar.cpp
@@ -19,11 +19,17 @@ void VitalsBar::addToMenu() {
     mainWindow->addWindowMenuAction(action);
 }
 
-void VitalsBar::toggle(bool checked) {
+void VitalsBar::toggle(bool checked, bool saveSetting) {
     if(vitalsBar != NULL) {
         vitalsBar->setVisible(checked);
-        clientSettings->setParameter("Window/vitalsBar", checked);
+        if (saveSetting) {
+            clientSettings->setParameter("Window/vitalsBar", checked);
+        }
     }
+}
+
+bool VitalsBar::isVisible() const {
+    return vitalsBar && vitalsBar->isVisible();
 }
 
 QProgressBar* VitalsBar::toolBar(const char* obName, QString bgColor) {

--- a/gui/vitalsbar.h
+++ b/gui/vitalsbar.h
@@ -19,6 +19,7 @@ public:
     void addToMenu();
     void load();
 
+    bool isVisible() const;
 private:
     MainWindow* mainWindow;
 
@@ -41,7 +42,7 @@ private:
 signals:
 
 public slots:
-    void toggle(bool checked);
+    void toggle(bool checked, bool saveSetting = true);
     void updateVitals(QString name, QString value);
 
 };


### PR DESCRIPTION
Now the Game window context menu includes the new button:
Distraction Free mode (inspired by Jetbrains IDEs).
This button will only show the game window, status
and command line. Toggling it back will show the usual
client.
EXPERIMENTAL! Please test on Windows.

![window_2021-04-28-21-57-51](https://user-images.githubusercontent.com/900250/116465223-3a6c2680-a86d-11eb-8336-4737fbb5b450.png)