### PR TITLE
Implemented commands support.

### DIFF
--- a/gui/hyperlinkservice.h
+++ b/gui/hyperlinkservice.h
@@ -13,6 +13,7 @@ public:
     ~HyperlinkService();
 
     static void addLink(QString &text, const QString &pattern, const QString &command);
+    static int createLink(QString &text, const QString &command, int indexStart, QString match);
     static QUrl createSearchElanthipediaUrl(const QString& text);
 
 public slots:
@@ -22,7 +23,6 @@ private:
     MainWindow* mainWindow;
     void handleActionCommand(const QString& action);
 
-    static int createLink(QString &text, const QString &command, int indexStart, QString match);
     static QString createCommand(QString text, QString command);
 
 signals:


### PR DESCRIPTION
Properly handle <d> tags to create clickable commands.

Since we have now the possibility to create clickable links, I've used this facility to handle commands sent from the server (in <d> tags).
This allows to make the client better utilize mouse, like the web client.
![window_2021-05-05-23-09-00](https://user-images.githubusercontent.com/900250/117209709-02c62700-adf7-11eb-8f30-6a9888b42366.png)
 