### PR TITLE
Workaround for issue #93

### DIFF
--- a/gui/gamewindow.cpp
+++ b/gui/gamewindow.cpp
@@ -171,7 +171,9 @@ void GameWindow::mouseDoubleClickEvent(QMouseEvent *e) {
 void GameWindow::mousePressEvent(QMouseEvent *e) {
     clickedAnchor = (e->button() == Qt::LeftButton) ?
         anchorAt(e->pos()) : QString();
-    QPlainTextEdit::mousePressEvent(e);
+    // Here we do not call QPlainTextEdit::mousePressEvent(e);
+    // due to the bug in QPlainTextEdit which picks up
+    // the character format if the url was clicked.
 }
 
 void GameWindow::mouseReleaseEvent(QMouseEvent *e) {


### PR DESCRIPTION
During experiments it was found that the click on URL leak
the character format in QPlainTextEdit.
If the mousepressed event is not propagated the leak is gone.