### PR TITLE
Fixed workaround for urls on LMB

### DIFF
--- a/gui/gamewindow.cpp
+++ b/gui/gamewindow.cpp
@@ -169,11 +169,15 @@ void GameWindow::mouseDoubleClickEvent(QMouseEvent *e) {
 }
 
 void GameWindow::mousePressEvent(QMouseEvent *e) {
-    clickedAnchor = (e->button() == Qt::LeftButton) ?
-        anchorAt(e->pos()) : QString();
-    // Here we do not call QPlainTextEdit::mousePressEvent(e);
-    // due to the bug in QPlainTextEdit which picks up
-    // the character format if the url was clicked.
+    auto anchor = anchorAt(e->pos());
+    if (e->button() == Qt::LeftButton && !anchor.isEmpty()) {
+        clickedAnchor = anchor;
+        // Here we do not call QPlainTextEdit::mousePressEvent(e);
+        // due to the bug in QPlainTextEdit which picks up
+        // the character format if the url was clicked.
+        return;
+    }
+    QPlainTextEdit::mousePressEvent(e);
 }
 
 void GameWindow::mouseReleaseEvent(QMouseEvent *e) {


### PR DESCRIPTION
I was so happy with a workaround so haven't given it a proper testing. Now I played a bit with it and found some strange behavior.
Previous workaround cancels a class of useful mouse events,
like selection. This fix restores it. The only thing not
working is to start selecting with dragging the mouse from
the middle of link.