### PR TITLE
Dictionary tooltips

### DIFF
--- a/gui/clientsettings.cpp
+++ b/gui/clientsettings.cpp
@@ -47,5 +47,9 @@ QString ClientSettings::profilePath() {
     return "";
 }
 
+void ClientSettings::remove(QString name) {
+    QSettings::remove(name);
+}
+
 ClientSettings::~ClientSettings() {        
 }

--- a/gui/clientsettings.h
+++ b/gui/clientsettings.h
@@ -23,6 +23,8 @@ public:
     bool hasValue(QString);
     QString profilePath();
 
+    void remove(QString name);
+
 private:
     explicit ClientSettings();
 

--- a/gui/dict/dictionarydialog.h
+++ b/gui/dict/dictionarydialog.h
@@ -26,11 +26,14 @@ private:
 private slots:
     void okPressed();
     void cancelPressed();
-
+    void onToggled(bool checked);
 
 private:
     QLineEdit* dictNameEdit;
     QLineEdit* dictArgumentsEdit;
+    QGroupBox* outputOptionsBox;
+    QRadioButton *dictionaryWinBtn;
+    QRadioButton *toolTipBtn;
     QGroupBox* hotkeyOptionsBox;
     
     DictionarySettings* settings;

--- a/gui/dict/dictionarydialog.h
+++ b/gui/dict/dictionarydialog.h
@@ -10,6 +10,8 @@ class QLineEdit;
 class DictionarySettings;
 class QGroupBox;
 
+class MainWindow;
+
 class DictionaryDialog : public QDialog {
     Q_OBJECT
 public:
@@ -29,9 +31,11 @@ private slots:
     void onToggled(bool checked);
 
 private:
+    MainWindow* mainWindow;
     QLineEdit* dictNameEdit;
     QLineEdit* dictArgumentsEdit;
     QGroupBox* outputOptionsBox;
+    QRadioButton *noOutputBtn;    
     QRadioButton *dictionaryWinBtn;
     QRadioButton *toolTipBtn;
     QGroupBox* hotkeyOptionsBox;

--- a/gui/dict/dictionaryservice.cpp
+++ b/gui/dict/dictionaryservice.cpp
@@ -6,86 +6,56 @@
 #include "windowfacade.h"
 #include "window/dictionarywindow.h"
 
-DictionaryService::DictionaryService(QObject* parent) :
-    QObject(parent),
-    settings(DictionarySettings::getInstance()),
-    process(new QProcess(this)) {
+DictionaryService::DictionaryService(QObject* parent)
+    : Parent(parent), settings(DictionarySettings::getInstance()) {
 
     mainWindow = (MainWindow*)parent;
-
-    connect(process, SIGNAL(errorOccurred(QProcess::ProcessError)),
-            this, SLOT(processErrorOccurred(QProcess::ProcessError)));
-    connect(process, SIGNAL(finished(int, QProcess::ExitStatus)),
-            this, SLOT(processFinished(int, QProcess::ExitStatus)));
-
-    connect(this, SIGNAL(translationFinished(QString)),
-            mainWindow->getWindowFacade()->getDictionaryWindow(), SLOT(write(QString)));
+    connect(this, SIGNAL(translationFinished(QString, QString)),
+            mainWindow->getWindowFacade()->getDictionaryWindow(), SLOT(write(QString, QString)));
     connect(this, SIGNAL(translationFailed(QString)),
             mainWindow->getWindowFacade()->getDictionaryWindow(), SLOT(write(QString)));
+    if (settings->getEnableToolTip()) {
+        connect(this, SIGNAL(translationFinished(QString, QString)),
+                mainWindow->getWindowFacade()->getGameWindow(),
+                SLOT(translationFinished(QString, QString)));
+        connect(this, SIGNAL(translationFailed(QString)),
+                mainWindow->getWindowFacade()->getGameWindow(), SLOT(translationFailed(QString)));
+    }
+    start();
 }
 
 DictionaryService::~DictionaryService() {}
 
 void DictionaryService::translate(const QString &word) {
-    if (process->state() == QProcess::NotRunning) {
-        QStringList args;
-        args = settings->getDictArguments().split(" ");
-        args << word;
-        process->start(settings->getDictCommand(), args);
+    Parent::addData(word);
+}
+
+void DictionaryService::onProcess(const QString& word) {
+    QStringList args;
+    QProcess process;
+    args = settings->getDictArguments().split(" ");
+    args << word;
+    process.start(settings->getDictCommand(), args);
+    process.waitForFinished();
+    if (process.exitStatus() != QProcess::NormalExit) {
+        emitError("Process crashed");
     } else {
-        emitError("Dictionary process is already running");
-    }
-}
-
-
-void DictionaryService::processErrorOccurred(QProcess::ProcessError error) {
-    QString reason;
-    switch (error) {
-    case QProcess::FailedToStart:
-        reason = "File not found, resource error";
-        break;
-    case QProcess::Crashed:
-        reason = "Process crashed";
-        break;
-    case QProcess::Timedout:
-        reason = "Process timed out";
-        break;
-    case QProcess::ReadError:
-        reason = "Read error";
-        break;
-    case QProcess::WriteError:
-        reason = "Write error";
-        break;
-    default:
-        reason = "Unknown error";
-        break;
-    }
-    emitError(reason);
-}
-
-void DictionaryService::processFinished(int exitCode, QProcess::ExitStatus exitStatus) {
-    switch (exitStatus) {
-    case QProcess::NormalExit:
-        switch (exitCode) {
+        switch (process.exitCode()) {
         case 0: {
-            QString translation = process->readAllStandardOutput();
-            emit translationFinished(translation);                        
+            QString translation = process.readAllStandardOutput();
+            qDebug() << "Translation finished: " << word;
+            emit translationFinished(word, translation);
         } break;
         case 21: { // dict error code "Approximate matches found"
-            QString translation = process->readAllStandardError();
-            emit translationFinished(translation);            
+            QString translation = process.readAllStandardError();
+            emit translationFinished(word, translation);
         } break;
         default:
             emitError("Word not found");
             break;
         }
-        break;
-    default:
-        emitError("Process crashed");
-        break;
     }
 }
-
 
 void DictionaryService::emitError(const QString& reason) {
     emit translationFailed("(Error: " + reason + ")\n");

--- a/gui/dict/dictionaryservice.h
+++ b/gui/dict/dictionaryservice.h
@@ -24,6 +24,7 @@ public:
 
     void translate(const QString& word);
 
+    void updateConnections();
 protected:
     void onProcess(const QString& data) override;
     
@@ -32,10 +33,10 @@ signals:
     void translationFailed(QString reason);
 
 private:
-    MainWindow* mainWindow;
-
     void emitError(const QString& reason);
+
 private:
+    MainWindow* mainWindow;
     DictionarySettings *settings;
 };
 

--- a/gui/dict/dictionaryservice.h
+++ b/gui/dict/dictionaryservice.h
@@ -4,11 +4,14 @@
 #include <QObject>
 #include <QProcess>
 
+#include "gui/workqueuethread.h"
+
 class DictionarySettings;
 class MainWindow;
 
-class DictionaryService : public QObject {
+class DictionaryService : public WorkQueueThread<QString> {
     Q_OBJECT
+    using Parent = WorkQueueThread<QString>;    
 public:
   enum ErrorCode {
     UnableToExecuteDict,
@@ -21,22 +24,19 @@ public:
 
     void translate(const QString& word);
 
+protected:
+    void onProcess(const QString& data) override;
+    
 signals:
-    void translationFinished(QString translation);
+    void translationFinished(QString word, QString translation);
     void translationFailed(QString reason);
 
 private:
     MainWindow* mainWindow;
 
     void emitError(const QString& reason);
-        
-private slots:
-    void processErrorOccurred(QProcess::ProcessError error);
-    void processFinished(int exitCode, QProcess::ExitStatus exitStatus);
-    
 private:
     DictionarySettings *settings;
-    QProcess* process;
 };
 
 #endif // DICTIONARYSERVICE_H

--- a/gui/dict/dictionarysettings.cpp
+++ b/gui/dict/dictionarysettings.cpp
@@ -61,6 +61,10 @@ Qt::KeyboardModifier DictionarySettings::getDoubleClickModifier() const {
 }
 
 
+bool DictionarySettings::getEnableToolTip() const {
+    return true;
+}
+
 DictionarySettings& DictionarySettings::setDictCommand(const QString &cmd) {
     clientSettings->setParameter(DICTIONARY_NAME_PATH, cmd);
     return *this;
@@ -81,3 +85,6 @@ DictionarySettings& DictionarySettings::setDoubleClickModifier(Qt::KeyboardModif
     return *this;
 }
 
+DictionarySettings& DictionarySettings::setEnableToolTip(bool enabled) {
+    return *this;
+}

--- a/gui/dict/dictionarysettings.h
+++ b/gui/dict/dictionarysettings.h
@@ -21,11 +21,13 @@ public:
     QString getDictArguments() const;
     bool getDoubleClickEnabled() const;
     Qt::KeyboardModifier getDoubleClickModifier() const;
+    bool getEnableToolTip() const;
 
     DictionarySettings& setDictCommand(const QString& cmd);
     DictionarySettings& setDictArguments(const QString& args);
     DictionarySettings& setDoubleClickEnabled(bool enabled);
     DictionarySettings& setDoubleClickModifier(Qt::KeyboardModifier modifier);
+    DictionarySettings& setEnableToolTip(bool enabled);
     
 private:
     explicit DictionarySettings();

--- a/gui/dict/dictionarysettings.h
+++ b/gui/dict/dictionarysettings.h
@@ -8,7 +8,12 @@ class ClientSettings;
 
 class DictionarySettings {
     friend class DictionarySettingsInstance;
-
+public:
+    enum class OutputType {
+        Disabled,
+        Window,
+        Tooltip
+    };
 public:
     static DictionarySettings* getInstance();
  
@@ -19,16 +24,14 @@ public:
 
     QString getDictCommand() const;
     QString getDictArguments() const;
-    bool getDoubleClickEnabled() const;
+    OutputType getDictOutputType();
     Qt::KeyboardModifier getDoubleClickModifier() const;
-    bool getEnableToolTip() const;
 
     DictionarySettings& setDictCommand(const QString& cmd);
     DictionarySettings& setDictArguments(const QString& args);
-    DictionarySettings& setDoubleClickEnabled(bool enabled);
     DictionarySettings& setDoubleClickModifier(Qt::KeyboardModifier modifier);
-    DictionarySettings& setEnableToolTip(bool enabled);
-    
+    DictionarySettings& setDictOutputType(OutputType type);
+
 private:
     explicit DictionarySettings();
 

--- a/gui/gamewindow.cpp
+++ b/gui/gamewindow.cpp
@@ -62,7 +62,8 @@ void GameWindow::showEvent(QShowEvent* event) {
 }
 
 bool GameWindow::event(QEvent* event) {
-    if (event->type() == QEvent::ToolTip) {
+    if (event->type() == QEvent::ToolTip
+        && dictionarySettings->getDictOutputType() == DictionarySettings::OutputType::Tooltip) {
         QHelpEvent* helpEvent = static_cast<QHelpEvent*>(event);
         QTextCursor cursor = cursorForPosition(helpEvent->pos());
         cursor.select(QTextCursor::WordUnderCursor);
@@ -70,7 +71,7 @@ bool GameWindow::event(QEvent* event) {
             currentDictEvent.active = true;
             currentDictEvent.word = cursor.selectedText();
             currentDictEvent.point = helpEvent->globalPos();
-            
+
             mainWindow->getDictionaryService()->translate(currentDictEvent.word);
         } else {
             QToolTip::hideText();
@@ -180,11 +181,11 @@ void GameWindow::resizeEvent(QResizeEvent *event) {
     QPlainTextEdit::resizeEvent(event);
 }
 
-void GameWindow::mouseDoubleClickEvent(QMouseEvent *e) {
+void GameWindow::mouseDoubleClickEvent(QMouseEvent* e) {
     QPlainTextEdit::mouseDoubleClickEvent(e);
-    if (dictionarySettings->getDoubleClickEnabled() &&
-        e->button() == Qt::LeftButton &&
-        e->modifiers() == dictionarySettings->getDoubleClickModifier()) {
+    if (dictionarySettings->getDictOutputType() == DictionarySettings::OutputType::Window
+        && e->button() == Qt::LeftButton
+        && e->modifiers() == dictionarySettings->getDoubleClickModifier()) {
         lookupInDictionary();
     }
 }

--- a/gui/gamewindow.h
+++ b/gui/gamewindow.h
@@ -46,7 +46,8 @@ private:
     void buildContextMenu();
 
     void showEvent(QShowEvent*);
-
+    bool event(QEvent *event);
+    
     MainWindow* mainWindow;
     WindowFacade* windowFacade;
     GeneralSettings* settings;
@@ -68,6 +69,15 @@ private:
     bool _stream;
 
     QString clickedAnchor;
+
+    struct DictionaryEvent {
+        QString word;
+        QPoint point;
+        bool active;
+    };
+
+    DictionaryEvent currentDictEvent;
+    
 signals:    
 
 private slots:
@@ -77,6 +87,8 @@ private slots:
     void enableCopy(bool);
     void saveAsHtml();
     void changeAppearance();
+    void translationFinished(QString word, QString translation);
+    void translationFailed(QString reason);
 
 public slots:
 

--- a/gui/genericwindow.cpp
+++ b/gui/genericwindow.cpp
@@ -177,11 +177,11 @@ void GenericWindow::contextMenuEvent(QContextMenuEvent* event) {
     menu->exec(point);
 }
 
-void GenericWindow::mouseDoubleClickEvent(QMouseEvent *e) {
+void GenericWindow::mouseDoubleClickEvent(QMouseEvent* e) {
     QPlainTextEdit::mouseDoubleClickEvent(e);
-    if (dictionarySettings->getDoubleClickEnabled() &&
-        e->button() == Qt::LeftButton &&
-        e->modifiers() == dictionarySettings->getDoubleClickModifier()) {
+    if (dictionarySettings->getDictOutputType() == DictionarySettings::OutputType::Window
+        && e->button() == Qt::LeftButton
+        && e->modifiers() == dictionarySettings->getDoubleClickModifier()) {
         lookupInDictionary();
     }
 }

--- a/gui/window/dictionarywindow.cpp
+++ b/gui/window/dictionarywindow.cpp
@@ -33,9 +33,10 @@ QDockWidget* DictionaryWindow::getDockWidget() {
     return dock;
 }
 
-void DictionaryWindow::write(QString text) {
+void DictionaryWindow::write(QString word, QString translation) {
+    (void)word;
     dock->setWindowTitle(visible ? DOCK_TITLE_DICTIONARY : DOCK_TITLE_DICTIONARY " *");
-    writer->addText(text);
+    writer->addText(translation);
     if(!writer->isRunning()) writer->start();
 }
 

--- a/gui/window/dictionarywindow.h
+++ b/gui/window/dictionarywindow.h
@@ -29,7 +29,7 @@ private:
 
 public slots:
     void setVisible(bool);
-    void write(QString text);
+    void write(QString word, QString translation);
 
 };
 


### PR DESCRIPTION
Minor update to the Dictionary functionality: implemented support for tooltips for Dictionary
    
Added user option to select tooltips instead of
Dictionary window for translation.
It is particularly useful in Distraction-free mode.
Conversion from previous settings is supported, by default
dictionary output is turned off, and the dictionary output
could be changed on fly between Off, To Window, To Tooltip.
Tooltips only work in Game window.
![dict_options](https://user-images.githubusercontent.com/900250/119379933-5a520700-bcc0-11eb-8317-3c610b4fd720.png)
![dict_tooltip](https://user-images.githubusercontent.com/900250/119379944-5f16bb00-bcc0-11eb-82dd-c028cef30e9e.png)
