### PR TITLE
Improve TCP APIs

### DIFF
--- a/gui/clientsettings.h
+++ b/gui/clientsettings.h
@@ -23,9 +23,14 @@ public:
     bool hasValue(QString);
     QString profilePath();
 
+    bool isDebug() const {
+        return DEBUG;
+    }
+
 private:
     explicit ClientSettings();
-
+    // TODO: move to ini or command line?
+    bool DEBUG = false;
 };
 
 class ClientSettingsInstance : public ClientSettings {

--- a/gui/clientsettings.h
+++ b/gui/clientsettings.h
@@ -23,17 +23,10 @@ public:
     bool hasValue(QString);
     QString profilePath();
 
-    bool isDebug() const {
-        return DEBUG;
-    }
-
 private:
     explicit ClientSettings();
-    // TODO: move to ini or command line?
-    bool DEBUG = false;
 };
 
-class ClientSettingsInstance : public ClientSettings {
-};
+class ClientSettingsInstance : public ClientSettings { };
 
 #endif // CLIENTSETTINGS_H

--- a/gui/defaultvalues.h
+++ b/gui/defaultvalues.h
@@ -94,6 +94,8 @@
 #define SCRIPT_LICH_RUBY "ruby"
 #define SCRIPT_LICH_ARGS "--dragonrealms --frostbite -g $host:$port"
 
+#define SCRIPT_STREAMING_ENABLED false
+
 #define WINDOW_FONT_ID "windowFont"
 #define WINDOW_FONT_SET "Set Font"
 #define WINDOW_FONT_CLEAR "Clear Font"

--- a/gui/eauthservice.cpp
+++ b/gui/eauthservice.cpp
@@ -5,6 +5,7 @@
 #include "tcpclient.h"
 
 EAuthService::EAuthService(QObject *parent) : QObject(parent) {
+    // TODO: Settings used only to get the debug state
     settings = ClientSettings::getInstance();
     tcpSocket = new QTcpSocket(this);
     tcpClient = (TcpClient*)parent;

--- a/gui/gamewindow.cpp
+++ b/gui/gamewindow.cpp
@@ -8,7 +8,7 @@
 #include "generalsettings.h"
 #include "dict/dictionarysettings.h"
 #include "dict/dictionaryservice.h"
-#include "hyperlinkservice.h"
+#include "hyperlinkutils.h"
 #include "defaultvalues.h"
 #include "globaldefines.h"
 #include "snapshot.h"
@@ -244,7 +244,7 @@ void GameWindow::lookupInElanthipedia() {
     if (textCursor.hasSelection()) {
         QString text = textCursor.selectedText().trimmed();
         if (text.size()) {
-            QDesktopServices::openUrl(HyperlinkService::createSearchElanthipediaUrl(text));
+            QDesktopServices::openUrl(HyperlinkUtils::createSearchElanthipediaUrl(text));
         }
     }
 }

--- a/gui/gui.pro
+++ b/gui/gui.pro
@@ -97,7 +97,7 @@ SOURCES += main.cpp\
     compass.cpp \
     genieutils.cpp \
     hyperlinkservice.cpp \
-    guisession.cpp
+    session.cpp
 
 HEADERS  += mainwindow.h \
     clientsettings.h \
@@ -159,7 +159,7 @@ HEADERS  += mainwindow.h \
     hyperlinkservice.h \
     concurrentqueue.h \
     workqueuethread.h \
-    guisession.h
+    session.h
 
 FORMS    += mainwindow.ui \
     macrodialog.ui \

--- a/gui/gui.pro
+++ b/gui/gui.pro
@@ -96,7 +96,8 @@ SOURCES += main.cpp\
     scriptsettingsdialog.cpp \
     compass.cpp \
     genieutils.cpp \
-    hyperlinkservice.cpp
+    hyperlinkservice.cpp \
+    guisession.cpp
 
 HEADERS  += mainwindow.h \
     clientsettings.h \
@@ -158,6 +159,7 @@ HEADERS  += mainwindow.h \
     hyperlinkservice.h \
     concurrentqueue.h \
     workqueuethread.h \
+    guisession.h
 
 FORMS    += mainwindow.ui \
     macrodialog.ui \

--- a/gui/gui.pro
+++ b/gui/gui.pro
@@ -97,6 +97,7 @@ SOURCES += main.cpp\
     compass.cpp \
     genieutils.cpp \
     hyperlinkservice.cpp \
+    hyperlinkutils.cpp \
     session.cpp
 
 HEADERS  += mainwindow.h \
@@ -157,6 +158,7 @@ HEADERS  += mainwindow.h \
     compass.h \
     genieutils.h \
     hyperlinkservice.h \
+    hyperlinkutils.h \
     concurrentqueue.h \
     workqueuethread.h \
     session.h

--- a/gui/gui.pro
+++ b/gui/gui.pro
@@ -98,7 +98,8 @@ SOURCES += main.cpp\
     genieutils.cpp \
     hyperlinkservice.cpp \
     hyperlinkutils.cpp \
-    session.cpp
+    session.cpp \
+    scriptstreamserver.cpp
 
 HEADERS  += mainwindow.h \
     clientsettings.h \
@@ -161,7 +162,8 @@ HEADERS  += mainwindow.h \
     hyperlinkutils.h \
     concurrentqueue.h \
     workqueuethread.h \
-    session.h
+    session.h \
+    scriptstreamserver.h
 
 FORMS    += mainwindow.ui \
     macrodialog.ui \

--- a/gui/hyperlinkservice.cpp
+++ b/gui/hyperlinkservice.cpp
@@ -6,6 +6,7 @@
 
 #include "globaldefines.h"
 #include "mainwindow.h"
+#include "hyperlinkutils.h"
 
 HyperlinkService::HyperlinkService(QObject *parent) : QObject(parent) {
     QDesktopServices::setUrlHandler(FROSTBITE_SCHEMA, this, "handleUrl");
@@ -32,49 +33,6 @@ void HyperlinkService::handleActionCommand(const QString &action) {
     } else {
         emit actionCommands(commands);
     }
-}
-
-void HyperlinkService::addLink(QString &text, const QString &pattern, const QString &command) {
-    QRegularExpression re(pattern + "(?=[^>]*(<|$))");
-    QRegularExpressionMatchIterator matchIterator = re.globalMatch(text);
-    int global = 0;
-    while (matchIterator.hasNext()) {
-        QRegularExpressionMatch match = matchIterator.next();
-        if(match.hasMatch()) {
-            int count = re.captureCount();
-            if(count == 1) {
-                global = HyperlinkService::createLink(text, command, match.capturedStart(0) + global, match.captured(0));
-            } else {
-                int inserted = 0;
-                for(int i = 1; i < count; i++) {
-                    inserted += HyperlinkService::createLink(text, command, match.capturedStart(i) + inserted, match.captured(i));
-                }
-            }
-        }
-    }
-}
-
-int HyperlinkService::createLink(QString &text, const QString &command, int indexStart, QString match) {
-    QString startTag = "<a href=\"" + HyperlinkService::createCommand(match, command) + "\">";
-    QString endTag = "</a>";
-
-    int startTagLength = startTag.length();
-    int indexEnd = indexStart + startTagLength + match.length();
-
-    text.insert(indexStart, startTag);
-    text.insert(indexEnd, endTag);
-
-    return startTagLength + endTag.length();
-}
-
-QString HyperlinkService::createCommand(QString text, QString command) {
-    command.replace(QRegExp("\\$1"), text);
-    return FROSTBITE_SCHEMA + QString("://a/") + command.toLocal8Bit().toBase64();
-}
-
-QUrl HyperlinkService::createSearchElanthipediaUrl(const QString& text) {
-    return QUrl(QString("https://elanthipedia.play.net/index.php?search=") +
-                QUrl::toPercentEncoding(text, " ") + QString("&title=Special%3ASearch&go=Go"));
 }
 
 HyperlinkService::~HyperlinkService() {  

--- a/gui/hyperlinkservice.h
+++ b/gui/hyperlinkservice.h
@@ -12,18 +12,12 @@ public:
     explicit HyperlinkService(QObject *parent);
     ~HyperlinkService();
 
-    static void addLink(QString &text, const QString &pattern, const QString &command);
-    static int createLink(QString &text, const QString &command, int indexStart, QString match);
-    static QUrl createSearchElanthipediaUrl(const QString& text);
-
 public slots:
     void handleUrl(const QUrl &url);     
 
 private:
     MainWindow* mainWindow;
     void handleActionCommand(const QString& action);
-
-    static QString createCommand(QString text, QString command);
 
 signals:
     void actionCommand(const QString& action);

--- a/gui/hyperlinkutils.cpp
+++ b/gui/hyperlinkutils.cpp
@@ -1,0 +1,59 @@
+#include "hyperlinkutils.h"
+
+#include <QRegExp>
+#include <QRegularExpression>
+
+#include "globaldefines.h"
+
+namespace {
+
+QString createCommand(QString text, QString command) {
+    command.replace(QRegExp("\\$1"), text);
+    return FROSTBITE_SCHEMA + QString("://a/") + command.toLocal8Bit().toBase64();
+}
+
+}
+
+namespace HyperlinkUtils
+{
+void addLink(QString &text, const QString &pattern, const QString &command) {
+    QRegularExpression re(pattern + "(?=[^>]*(<|$))");
+    QRegularExpressionMatchIterator matchIterator = re.globalMatch(text);
+    int global = 0;
+    while (matchIterator.hasNext()) {
+        QRegularExpressionMatch match = matchIterator.next();
+        if(match.hasMatch()) {
+            int count = re.captureCount();
+            if(count == 1) {
+                global = createLink(text, command, match.capturedStart(0) + global, match.captured(0));
+            } else {
+                int inserted = 0;
+                for(int i = 1; i < count; i++) {
+                    inserted += createLink(text, command, match.capturedStart(i) + inserted, match.captured(i));
+                }
+            }
+        }
+    }
+}
+
+int createLink(QString &text, const QString &command, int indexStart, QString match) {
+    QString startTag = "<a href=\"" + createCommand(match, command) + "\">";
+    QString endTag = "</a>";
+
+    int startTagLength = startTag.length();
+    int indexEnd = indexStart + startTagLength + match.length();
+
+    text.insert(indexStart, startTag);
+    text.insert(indexEnd, endTag);
+
+    return startTagLength + endTag.length();
+}
+
+
+QUrl createSearchElanthipediaUrl(const QString& text) {
+    return QUrl(QString("https://elanthipedia.play.net/index.php?search=") +
+                QUrl::toPercentEncoding(text, " ") + QString("&title=Special%3ASearch&go=Go"));
+}
+
+}
+

--- a/gui/hyperlinkutils.h
+++ b/gui/hyperlinkutils.h
@@ -1,0 +1,15 @@
+#ifndef HYPERLINKUTILS_H
+#define HYPERLINKUTILS_H
+
+#include <QString>
+#include <QUrl>
+
+namespace HyperlinkUtils {
+
+void addLink(QString& text, const QString& pattern, const QString& command);
+int createLink(QString& text, const QString& command, int indexStart, QString match);
+QUrl createSearchElanthipediaUrl(const QString& text);
+
+}
+
+#endif // HYPERLINKUTILS_H

--- a/gui/lich/lich.cpp
+++ b/gui/lich/lich.cpp
@@ -6,9 +6,15 @@
 #include "defaultvalues.h"
 
 Lich::Lich(QObject *parent) : QObject(parent), lich_proc(new QProcess(this)) {
+    // TODO: Remove this dependency from MainWindow.
+    // The MainWindow only used to get windowFacade, while
+    // windowFacade is only used to call its method
+    // writeGameWindow, which could be converted to
+    // emitting signal as well.
     mainWindow = (MainWindow*)parent;
     windowFacade = mainWindow->getWindowFacade();
 
+    // ClientSettigs only used in ::run method
     clientSettings = ClientSettings::getInstance();
 
     connect(lich_proc, SIGNAL(readyReadStandardOutput()), this, SLOT(displayOutputMsg()));
@@ -19,6 +25,9 @@ Lich::Lich(QObject *parent) : QObject(parent), lich_proc(new QProcess(this)) {
 }
 
 void Lich::run(QString host, QString port) {
+    // TODO: Probably supply these settings as arguments?
+    // Then the dependency on both clientsettings.h and
+    // defaultvalues.h could be removed.
     QString lichLocation = clientSettings->getQStringNotBlank("Script/lichLocation", SCRIPT_LICH_LOCATION);
     QString ruby = clientSettings->getQStringNotBlank("Script/lichRuby", SCRIPT_LICH_RUBY);
     QString lichArgs = clientSettings->getQStringNotBlank("Script/lichArguments", SCRIPT_LICH_ARGS);

--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -1,5 +1,6 @@
 #include <guiapplication.h>
 #include "mainwindow.h"
+#include "clientsettings.h"
 
 #include "log4qt/logger.h"
 #include <log4qt/propertyconfigurator.h>
@@ -11,8 +12,6 @@
 #include <stdlib.h>
 #include <unistd.h>
 #endif
-
-bool MainWindow::DEBUG = false;
 
 #ifdef __linux__
 void handler(int sig) {
@@ -79,7 +78,7 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    if(!MainWindow::DEBUG) {
+    if(!ClientSettings::getInstance()->isDebug()) {
         w.openConnectDialog();
     }
     return a.exec();

--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -1,6 +1,5 @@
 #include <guiapplication.h>
 #include "mainwindow.h"
-#include "clientsettings.h"
 
 #include "log4qt/logger.h"
 #include <log4qt/propertyconfigurator.h>
@@ -13,72 +12,76 @@
 #include <unistd.h>
 #endif
 
+bool MainWindow::DEBUG = false;
+
 #ifdef __linux__
 void handler(int sig) {
-  void *array[50];
-  size_t size;
+    void* array[50];
+    size_t size;
 
-  // get void*'s for all entries on the stack
-  size = backtrace(array, 50);
+    // get void*'s for all entries on the stack
+    size = backtrace(array, 50);
 
-  // print out all the frames to stderr
-  fprintf(stderr, "Error: signal %d:\n", sig);
-  backtrace_symbols_fd(array, size, STDERR_FILENO);
-  exit(1);
+    // print out all the frames to stderr
+    fprintf(stderr, "Error: signal %d:\n", sig);
+    backtrace_symbols_fd(array, size, STDERR_FILENO);
+    exit(1);
 }
 #endif
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
     QCoreApplication::setApplicationVersion(QString(RELEASE_VERSION));
     QCoreApplication::setApplicationName("Frostbite");
 
     static const char ENV_VAR_QT_DEVICE_PIXEL_RATIO[] = "QT_DEVICE_PIXEL_RATIO";
     if (!qEnvironmentVariableIsSet(ENV_VAR_QT_DEVICE_PIXEL_RATIO)
-            && !qEnvironmentVariableIsSet("QT_AUTO_SCREEN_SCALE_FACTOR")
-            && !qEnvironmentVariableIsSet("QT_SCALE_FACTOR")
-            && !qEnvironmentVariableIsSet("QT_SCREEN_SCALE_FACTORS")) {
+        && !qEnvironmentVariableIsSet("QT_AUTO_SCREEN_SCALE_FACTOR")
+        && !qEnvironmentVariableIsSet("QT_SCALE_FACTOR")
+        && !qEnvironmentVariableIsSet("QT_SCREEN_SCALE_FACTORS")) {
         QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
         QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
     }
 
-    #ifdef __linux__
+#ifdef __linux__
     signal(SIGSEGV, handler);
-    #endif
+#endif
 
     GuiApplication a(argc, argv);
 
     /* Prohibit running more than one copy of appliction. */
-    if(a.isRunning()) {
+    if (a.isRunning()) {
         Log4Qt::Logger::logger(QLatin1String("ErrorLogger"))->info("Application already running.");
         a.sendMessage("show", 1000);
         exit(0);
     }
 
-    Log4Qt::PropertyConfigurator::configure(QApplication::applicationDirPath()  + "/log.ini");
+    Log4Qt::PropertyConfigurator::configure(QApplication::applicationDirPath() + "/log.ini");
 
     QApplication::addLibraryPath(QApplication::applicationDirPath());
 
     MainWindow w;
     w.show();
 
-    QObject::connect(&a, SIGNAL(messageReceived(const QString&)), &w, SLOT(handleAppMessage(const QString&)));
+    QObject::connect(&a, SIGNAL(messageReceived(const QString&)), &w,
+                     SLOT(handleAppMessage(const QString&)));
 
     QStringList args = QCoreApplication::arguments();
-    if(!args.isEmpty() && args.count() > 1) {
-        if(args.at(1).startsWith("--port=")) {
+    if (!args.isEmpty() && args.count() > 1) {
+        if (args.at(1).startsWith("--port=")) {
             w.openLocalConnection(args.at(1).mid(7).trimmed());
         } else if (QFile(args.at(1)).exists()) {
             QSettings settings(args.at(1), QSettings::IniFormat);
-            if(settings.contains("GAMEHOST") && settings.contains("GAMEPORT") && settings.contains("KEY")){
-              w.openConnection(settings.value("GAMEHOST").toString(),
-                               settings.value("GAMEPORT").toString(),
-                               settings.value("KEY").toString());
+            if (settings.contains("GAMEHOST") && settings.contains("GAMEPORT")
+                && settings.contains("KEY")) {
+                w.openConnection(settings.value("GAMEHOST").toString(),
+                                 settings.value("GAMEPORT").toString(),
+                                 settings.value("KEY").toString());
             }
             return a.exec();
         }
     }
 
-    if(!ClientSettings::getInstance()->isDebug()) {
+    if (!MainWindow::DEBUG) {
         w.openConnectDialog();
     }
     return a.exec();

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -400,26 +400,9 @@ void MainWindow::setMainTitle(QString roomName) {
     setWindowTitle("The Frostbite Client" + roomName);
 }
 
-void MainWindow::connectEnabled(bool enabled) {
-    ui->actionConnect->setEnabled(enabled);
+void MainWindow::enableConnectButton(bool enable) {
+    ui->actionConnect->setEnabled(enable);
 }
-
-void MainWindow::connectStarted() {
-    windowFacade->writeGameWindow("Connecting ...");    
-}
-
-void MainWindow::connectSucceeded() {
-    windowFacade->writeGameWindow("Connection established.<br/>");
-}
-
-void MainWindow::connectFailed(QString reason) {
-    windowFacade->writeGameWindow("<br><br>"
-        "*<br>"
-        "* " + reason.toLocal8Bit() + "<br>"
-        "*<br>"
-        "<br><br>");    
-}
-
 
 void MainWindow::handleAppMessage(const QString& msg) {
     if(msg == "show") {

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -28,7 +28,7 @@
 #include "compass/compassview.h"
 #include "macrosettings.h"
 #include "hyperlinkservice.h"
-#include "guisession.h"
+#include "session.h"
 
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWindow) {
     ui->setupUi(this);
@@ -204,7 +204,7 @@ void MainWindow::loadClient() {
     xmlParser = new XmlParserThread(this);        
     tcpClient = new TcpClient(this, DEBUG);
     
-    session = new GUISession(this, tcpClient, xmlParser);
+    session = new Session(this, tcpClient, xmlParser);
         
     menuHandler = new MenuHandler(this);
     menuHandler->loadProfilesMenu();

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -7,6 +7,7 @@
 
 #include "windowfacade.h"
 #include "tcpclient.h"
+#include "xml/xmlparserthread.h"
 #include "toolbar/toolbar.h"
 #include "clientsettings.h"
 #include "commandline.h"
@@ -27,6 +28,7 @@
 #include "compass/compassview.h"
 #include "macrosettings.h"
 #include "hyperlinkservice.h"
+#include "guisession.h"
 
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWindow) {
     ui->setupUi(this);
@@ -199,8 +201,11 @@ void MainWindow::loadClient() {
 
     scriptService = new ScriptService(this);
 
+    xmlParser = new XmlParserThread(this);        
     tcpClient = new TcpClient(this, DEBUG);
-
+    
+    session = new GUISession(this, tcpClient, xmlParser);
+        
     menuHandler = new MenuHandler(this);
     menuHandler->loadProfilesMenu();
 

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -215,6 +215,13 @@ void MainWindow::loadClient() {
     
     connect(ui->menuBar, SIGNAL(triggered(QAction*)), menuHandler, SLOT(menuTriggered(QAction*)));
     connect(ui->menuBar, SIGNAL(hovered(QAction*)), menuHandler, SLOT(menuHovered(QAction*)));
+
+    // Connect to TCP Client events and connect it to our events
+    connect(tcpClient, SIGNAL(connectAvailable(bool)), this, SLOT(connectEnabled(bool)));
+    connect(this, SIGNAL(profileChanged()), tcpClient, SLOT(reloadSettings()));
+    connect(tcpClient, SIGNAL(connectStarted()), this, SLOT(connectStarted()));
+    connect(tcpClient, SIGNAL(connectSucceeded()), this, SLOT(connectSucceeded()));
+    connect(tcpClient, SIGNAL(connectFailed(QString)), this, SLOT(connectFailed(QString)));
 }
 
 WindowFacade* MainWindow::getWindowFacade() {
@@ -399,6 +406,23 @@ void MainWindow::setMainTitle(QString roomName) {
 void MainWindow::connectEnabled(bool enabled) {
     ui->actionConnect->setEnabled(enabled);
 }
+
+void MainWindow::connectStarted() {
+    windowFacade->writeGameWindow("Connecting ...");    
+}
+
+void MainWindow::connectSucceeded() {
+    windowFacade->writeGameWindow("Connection established.<br/>");
+}
+
+void MainWindow::connectFailed(QString reason) {
+    windowFacade->writeGameWindow("<br><br>"
+        "*<br>"
+        "* " + reason.toLocal8Bit() + "<br>"
+        "*<br>"
+        "<br><br>");    
+}
+
 
 void MainWindow::handleAppMessage(const QString& msg) {
     if(msg == "show") {

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -199,7 +199,7 @@ void MainWindow::loadClient() {
 
     scriptService = new ScriptService(this);
 
-    tcpClient = new TcpClient(this);
+    tcpClient = new TcpClient(this, DEBUG);
 
     menuHandler = new MenuHandler(this);
     menuHandler->loadProfilesMenu();

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -28,6 +28,7 @@
 #include "macrosettings.h"
 #include "hyperlinkservice.h"
 #include "session.h"
+#include "scriptstreamserver.h"
 
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWindow) {
     ui->setupUi(this);
@@ -113,6 +114,7 @@ void MainWindow::toggleDistractionFreeMode() {
 
 void MainWindow::updateScriptSettings() {
     scriptApiServer->reloadSettings();
+    scriptStreamServer->reloadSettings();
 }
 
 void MainWindow::menuVolumeChanged(int volume) {
@@ -208,6 +210,7 @@ void MainWindow::loadClient() {
     menuHandler->loadProfilesMenu();
 
     scriptApiServer = new ScriptApiServer(this);
+    scriptStreamServer = new ScriptStreamServer(this);
 
     dictionaryService = new DictionaryService(this);
 
@@ -218,7 +221,6 @@ void MainWindow::loadClient() {
     
     connect(ui->menuBar, SIGNAL(triggered(QAction*)), menuHandler, SLOT(menuTriggered(QAction*)));
     connect(ui->menuBar, SIGNAL(hovered(QAction*)), menuHandler, SLOT(menuHovered(QAction*)));
-
 }
 
 WindowFacade* MainWindow::getWindowFacade() {
@@ -243,6 +245,10 @@ CommandLine* MainWindow::getCommandLine() {
 
 ScriptService* MainWindow::getScriptService() {
     return scriptService;
+}
+
+ScriptStreamServer* MainWindow::getScriptStreamServer() {
+    return scriptStreamServer;
 }
 
 DictionaryService* MainWindow::getDictionaryService() {

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -6,7 +6,6 @@
 #include "cleanlooks/qcleanlooksstyle.h"
 
 #include "windowfacade.h"
-#include "tcpclient.h"
 #include "xml/xmlparserthread.h"
 #include "toolbar/toolbar.h"
 #include "clientsettings.h"
@@ -142,11 +141,11 @@ void MainWindow::reloadSettings() {
 }
 
 void MainWindow::openConnection(QString host, QString port, QString key) {
-    tcpClient->connectToHost(host, port, key);
+    session->openConnection(host, port, key);
 }
 
 void MainWindow::openLocalConnection(QString port) {
-    tcpClient->connectToLocalPort(port);
+    session->openLocalConnection(port);
 }
 
 MenuHandler* MainWindow::getMenuHandler() {
@@ -201,10 +200,7 @@ void MainWindow::loadClient() {
 
     scriptService = new ScriptService(this);
 
-    xmlParser = new XmlParserThread(this);        
-    tcpClient = new TcpClient(this, DEBUG);
-    
-    session = new Session(this, tcpClient, xmlParser);
+    session = new Session(this, DEBUG);
         
     menuHandler = new MenuHandler(this);
     menuHandler->loadProfilesMenu();
@@ -221,12 +217,6 @@ void MainWindow::loadClient() {
     connect(ui->menuBar, SIGNAL(triggered(QAction*)), menuHandler, SLOT(menuTriggered(QAction*)));
     connect(ui->menuBar, SIGNAL(hovered(QAction*)), menuHandler, SLOT(menuHovered(QAction*)));
 
-    // Connect to TCP Client events and connect it to our events
-    connect(tcpClient, SIGNAL(connectAvailable(bool)), this, SLOT(connectEnabled(bool)));
-    connect(this, SIGNAL(profileChanged()), tcpClient, SLOT(reloadSettings()));
-    connect(tcpClient, SIGNAL(connectStarted()), this, SLOT(connectStarted()));
-    connect(tcpClient, SIGNAL(connectSucceeded()), this, SLOT(connectSucceeded()));
-    connect(tcpClient, SIGNAL(connectFailed(QString)), this, SLOT(connectFailed(QString)));
 }
 
 WindowFacade* MainWindow::getWindowFacade() {
@@ -242,7 +232,7 @@ VitalsBar* MainWindow::getVitalsBar() {
 }
 
 TcpClient* MainWindow::getTcpClient() {
-    return tcpClient;
+    return session->getTcpClient();
 }
 
 CommandLine* MainWindow::getCommandLine() {
@@ -466,7 +456,6 @@ void MainWindow::actionCommands(const QStringList& commands) {
 }
 
 MainWindow::~MainWindow() {
-    delete tcpClient;
     delete ui;
     delete toolBar;
     delete windowFacade;

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -173,12 +173,14 @@ void MainWindow::loadClient() {
     mainWidgetLayout->setContentsMargins(0,0,0,0);
     ui->mainLayout->addWidget(mainWidget);
 
-    
+    // Timer bar created before the Toolbar because
+    // alert highlighter used in Toolbar connects to it.
+    timerBar = new TimerBar(this);
+    timerBar->load();
+
     toolBar = new Toolbar(this);
     toolBar->loadToolbar();
 
-    timerBar = new TimerBar(this);
-    timerBar->load();
 
     vitalsBar = new VitalsBar(this);
     vitalsBar->load();

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -36,7 +36,6 @@ class ScriptApiServer;
 class DictionaryService;
 class ClientSettings;
 class HyperlinkService;
-class XmlParserThread;
 class Session;
 
 class MainWindow : public QMainWindow {
@@ -119,8 +118,6 @@ private:
     } distractionFreeModeParams;
     WindowFacade* windowFacade;
     Toolbar* toolBar;
-    XmlParserThread* xmlParser;
-    TcpClient* tcpClient;
     Session* session;
     ClientSettings* settings;
     GeneralSettings* generalSettings;

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -37,6 +37,7 @@ class DictionaryService;
 class ClientSettings;
 class HyperlinkService;
 class Session;
+class ScriptStreamServer;
 
 class MainWindow : public QMainWindow {
     Q_OBJECT
@@ -101,6 +102,7 @@ public:
     TcpClient* getTcpClient();
     CommandLine* getCommandLine();
     ScriptService* getScriptService();
+    ScriptStreamServer* getScriptStreamServer();
     DictionaryService* getDictionaryService();
     TimerBar* getTimerBar();
     Tray* getTray();
@@ -126,6 +128,7 @@ private:
     MenuHandler* menuHandler;
     ScriptService* scriptService;
     ScriptApiServer* scriptApiServer;
+    ScriptStreamServer* scriptStreamServer;
     DictionaryService* dictionaryService;
     HyperlinkService* hyperlinkService;
     QMenu* commandMenu;

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -103,6 +103,9 @@ public:
     DictionaryService* getDictionaryService();
     TimerBar* getTimerBar();
     Tray* getTray();
+    
+public:
+    static bool DEBUG;
 
 private:
     Ui::MainWindow* ui;

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -36,7 +36,8 @@ class ScriptApiServer;
 class DictionaryService;
 class ClientSettings;
 class HyperlinkService;
-
+class XmlParserThread;
+class GUISession;
 
 class MainWindow : public QMainWindow {
     Q_OBJECT
@@ -118,7 +119,9 @@ private:
     } distractionFreeModeParams;
     WindowFacade* windowFacade;
     Toolbar* toolBar;
+    XmlParserThread* xmlParser;
     TcpClient* tcpClient;
+    GUISession* session;
     ClientSettings* settings;
     GeneralSettings* generalSettings;
     CommandLine* cmdLine;

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -37,7 +37,7 @@ class DictionaryService;
 class ClientSettings;
 class HyperlinkService;
 class XmlParserThread;
-class GUISession;
+class Session;
 
 class MainWindow : public QMainWindow {
     Q_OBJECT
@@ -121,7 +121,7 @@ private:
     Toolbar* toolBar;
     XmlParserThread* xmlParser;
     TcpClient* tcpClient;
-    GUISession* session;
+    Session* session;
     ClientSettings* settings;
     GeneralSettings* generalSettings;
     CommandLine* cmdLine;

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -45,8 +45,6 @@ public:
     MainWindow(QWidget *parent = 0);
     ~MainWindow();
 
-    static bool DEBUG;
-
     void addDockWidgetMainWindow(Qt::DockWidgetArea, QDockWidget*);
     void removeDockWidgetMainWindow(QDockWidget* dock);
     void addWindowMenuAction(QAction* action);
@@ -77,7 +75,6 @@ public:
     void setMenuMutedVisible(bool enabled);
 
     void setToolbarAllowedAreas(Qt::ToolBarAreas);
-    void connectEnabled(bool);    
     void toggleFullScreen();
     void toggleMaximized();
     void updateProfileSettings(QString, QString);        
@@ -156,7 +153,11 @@ public slots:
     void reloadSettings();
     void actionCommand(const QString&);
     void actionCommands(const QStringList&);
-    void toggleDistractionFreeMode();    
+    void toggleDistractionFreeMode();
+    void connectEnabled(bool);    
+    void connectStarted();
+    void connectSucceeded();
+    void connectFailed(QString);
 };
 
 #endif // MAINWINDOW_H

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -92,6 +92,7 @@ public:
     void showMaps();
 
     void enableMapsMenu(bool enabled);
+    void enableConnectButton(bool enabled);
 
     MenuHandler* getMenuHandler();
     WindowFacade* getWindowFacade();
@@ -157,10 +158,6 @@ public slots:
     void actionCommand(const QString&);
     void actionCommands(const QStringList&);
     void toggleDistractionFreeMode();
-    void connectEnabled(bool);    
-    void connectStarted();
-    void connectSucceeded();
-    void connectFailed(QString);
 };
 
 #endif // MAINWINDOW_H

--- a/gui/scriptapiserver.cpp
+++ b/gui/scriptapiserver.cpp
@@ -65,7 +65,7 @@ void ScriptApiServer::openSession() {
     if(tcpServer->isListening()) tcpServer->close();
     if (!tcpServer->listen(QHostAddress::LocalHost, clientSettings->getParameter("Script/apiPort", 0).toInt())) {
         Log4Qt::Logger::logger(QLatin1String("ErrorLogger"))->
-                info("Unable to start server" + tcpServer->errorString());
+                info("Unable to start API server" + tcpServer->errorString());
         return;
     }
     apiSettings->setParameter("ApiServer/port", tcpServer->serverPort());

--- a/gui/scriptservice.cpp
+++ b/gui/scriptservice.cpp
@@ -8,6 +8,7 @@
 #include "windowfacade.h"
 #include "defaultvalues.h"
 #include "clientsettings.h"
+#include "scriptstreamserver.h"
 
 ScriptService::ScriptService(QObject *parent) : QObject(parent) {
     mainWindow = (MainWindow*)parent;
@@ -24,6 +25,8 @@ ScriptService::ScriptService(QObject *parent) : QObject(parent) {
 
     connect(this, SIGNAL(killScript()), script, SLOT(killScript()));
     connect(this, SIGNAL(sendMessage(QByteArray)), script, SLOT(sendMessage(QByteArray)));
+    connect(scriptWriter, SIGNAL(writeText(QByteArray)),
+            this, SLOT(writeOutgoingMessage(QByteArray)));
 }
 
 bool ScriptService::isScriptActive() {
@@ -99,8 +102,13 @@ void ScriptService::writeGameWindow(QByteArray command) {
 }
 
 void ScriptService::writeScriptText(QByteArray text) {
-    if(!text.isEmpty() && this->isScriptActive()) {
-        scriptWriter->addData(text.data());
+    if (!text.isEmpty()) {
+        // Script Service delivers script text to both streaming
+        // server and the running script
+        mainWindow->getScriptStreamServer()->writeData(text);
+        if (this->isScriptActive()) {
+            scriptWriter->addData(text.data());
+        }
     }
 }
 

--- a/gui/scriptsettingsdialog.ui
+++ b/gui/scriptsettingsdialog.ui
@@ -296,6 +296,55 @@
        </item>
       </layout>
      </widget>
+
+
+     <widget class="QWidget" name="streamingServerTab">
+       <attribute name="title">
+         <string>Streaming API Server</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_11">
+           <item>
+            <widget class="QCheckBox" name="streamingServerEnabled">
+             <property name="text">
+              <string>Enabled</string>
+             </property>
+            </widget>
+           </item>
+         <item>
+           <widget class="QGroupBox" name="groupBox_9">
+             <property name="title">
+               <string>Streaming Server TCP port</string>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_13">
+               <item>
+                 <layout class="QHBoxLayout" name="horizontalLayout_13">
+                   <item>
+                     <widget class="QLineEdit" name="streamingPortInput">
+                       <property name="placeholderText">
+                         <string>auto 1024 - 65535 </string>
+                       </property>
+                     </widget>
+                   </item>
+                 </layout>
+               </item>
+             </layout>
+           </widget>
+         </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>         
+       </layout>
+     </widget>
     </widget>
    </item>
    <item>

--- a/gui/scriptstreamserver.cpp
+++ b/gui/scriptstreamserver.cpp
@@ -1,0 +1,83 @@
+#include "scriptstreamserver.h"
+
+#include "log4qt/logger.h"
+
+#include "clientsettings.h"
+#include "defaultvalues.h"
+
+ScriptStreamServer::ScriptStreamServer(QObject* parent) : Parent(parent) {
+    start();
+    connect(&server, SIGNAL(newConnection()), this, SLOT(onNewConnection()));
+    connect(this, SIGNAL(writeText(QByteArray)), this, SLOT(sendMessage(QByteArray)));
+
+    restart();
+}
+
+ScriptStreamServer::~ScriptStreamServer() {
+    close();
+}
+
+void ScriptStreamServer::writeData(QString message) {
+    // only add to the queue if we have sockets connected
+    // and server is listening, no need to waste resources
+    if (server.isListening() && sockets.size()) {
+        Parent::addData(message);
+    }
+}
+
+void ScriptStreamServer::onNewConnection() {
+    QTcpSocket* clientSocket = server.nextPendingConnection();
+    connect(clientSocket, SIGNAL(stateChanged(QAbstractSocket::SocketState)), this,
+            SLOT(onSocketStateChanged(QAbstractSocket::SocketState)));
+
+    sockets.push_back(clientSocket);
+}
+
+void ScriptStreamServer::onSocketStateChanged(QAbstractSocket::SocketState socketState) {
+    if (socketState == QAbstractSocket::UnconnectedState) {
+        QTcpSocket* sender = static_cast<QTcpSocket*>(QObject::sender());
+        sockets.removeOne(sender);
+    }
+}
+
+void ScriptStreamServer::reloadSettings() {
+    restart();
+}
+
+void ScriptStreamServer::sendMessage(QByteArray message) {
+    for (QTcpSocket* socket : sockets) {
+        socket->write(message.append('\n'));
+    }
+}
+
+void ScriptStreamServer::close() {
+    for (QTcpSocket* socket : sockets) {
+        socket->close();
+    }
+    sockets.clear();
+    if (server.isListening()) {
+        server.close();
+    }
+}
+
+void ScriptStreamServer::restart() {
+    bool enabled = ClientSettings::getInstance()
+                           ->getParameter("Script/streamingServerEnabled", SCRIPT_STREAMING_ENABLED)
+                           .toBool();
+    int port = ClientSettings::getInstance()->getParameter("Script/streamingServerPort", 0).toInt();
+
+    // check if need to close the server
+    if (enabled && server.isListening() && port == server.serverPort()) {
+        // no changes needed
+        return;
+    }
+
+    close();
+    // start server if necessary
+    if (enabled) {
+        if (!server.listen(QHostAddress::Any, port)) {
+            Log4Qt::Logger::logger(QLatin1String("ErrorLogger"))
+                    ->info("Unable to start Streaming server" + server.errorString());
+        }
+    }
+}

--- a/gui/scriptstreamserver.h
+++ b/gui/scriptstreamserver.h
@@ -1,0 +1,39 @@
+#ifndef SCRIPTSTREAMSERVER_H
+#define SCRIPTSTREAMSERVER_H
+
+#include "qobjectdefs.h"
+#include <QTcpServer>
+#include <QTcpSocket>
+#include <QByteArray>
+
+#include "scriptwriterthread.h"
+
+class ScriptStreamServer : public ScriptWriterThread {
+    Q_OBJECT
+public:
+    using Parent = ScriptWriterThread;
+
+public:
+    explicit ScriptStreamServer(QObject* parent = 0);
+    virtual ~ScriptStreamServer();
+
+private:
+    void restart();
+    void close();
+
+    QTcpServer server;
+    QList<QTcpSocket*> sockets;
+
+public slots:
+    void reloadSettings();
+    // Put the message to the queue for processing and sending
+    void writeData(QString message);
+private slots:
+    // connection management
+    void onNewConnection();
+    void onSocketStateChanged(QAbstractSocket::SocketState socketState);
+    // send data to open sockets
+    void sendMessage(QByteArray message);
+};
+
+#endif // SCRIPTSTREAMSERVER_H

--- a/gui/scriptwriterthread.cpp
+++ b/gui/scriptwriterthread.cpp
@@ -6,9 +6,6 @@ ScriptWriterThread::ScriptWriterThread(QObject *parent) {
     scriptService = (ScriptService*)parent;
 
     rxRemoveTags.setPattern("<[^>]*>");
-
-    connect(this, SIGNAL(writeText(QByteArray)),
-            scriptService, SLOT(writeOutgoingMessage(QByteArray)));
 }
 
 void ScriptWriterThread::onProcess(const QString& lines) {

--- a/gui/session.cpp
+++ b/gui/session.cpp
@@ -1,0 +1,21 @@
+#include "session.h"
+
+#include "mainwindow.h"
+#include "tcpclient.h"
+#include "xml/xmlparserthread.h"
+
+Session::Session(MainWindow* parent, TcpClient* client, XmlParserThread* parser) : QObject(parent), tcpClient(client), xmlParser(parser) {
+    connect(tcpClient, SIGNAL(addToQueue(QByteArray)), xmlParser, SLOT(addData(QByteArray)));
+    connect(tcpClient, SIGNAL(diconnected()), xmlParser, SLOT(flushStream()));
+    connect(xmlParser, SIGNAL(writeSettings()), tcpClient, SLOT(writeSettings()));
+    connect(xmlParser, SIGNAL(writeModeSettings()), tcpClient, SLOT(writeModeSettings()));
+    connect(xmlParser, SIGNAL(writeDefaultSettings(QString)), tcpClient, SLOT(writeDefaultSettings(QString)));
+    connect(xmlParser, SIGNAL(gameModeIsCmgr(bool)), tcpClient, SLOT(setGameModeCmgr(bool)));
+
+    
+    if(!xmlParser->isRunning()) {
+        xmlParser->start();
+    }
+
+    tcpClient->init();
+}

--- a/gui/session.cpp
+++ b/gui/session.cpp
@@ -60,12 +60,12 @@ void Session::bindParserAndClient() {
 }
 
 void Session::bindClientStatus() {
-    // Connect TCP Client events to main window events, to
+    // Connect TCP Client events to Session slots, to
     // report status
-    connect(tcpClient, SIGNAL(connectAvailable(bool)), mainWindow, SLOT(connectEnabled(bool)));
-    connect(tcpClient, SIGNAL(connectStarted()), mainWindow, SLOT(connectStarted()));
-    connect(tcpClient, SIGNAL(connectSucceeded()), mainWindow, SLOT(connectSucceeded()));
-    connect(tcpClient, SIGNAL(connectFailed(QString)), mainWindow, SLOT(connectFailed(QString)));
+    connect(tcpClient, SIGNAL(connectAvailable(bool)), this, SLOT(connectAvailable(bool)));
+    connect(tcpClient, SIGNAL(connectStarted()), this, SLOT(connectStarted()));
+    connect(tcpClient, SIGNAL(connectSucceeded()), this, SLOT(connectSucceeded()));
+    connect(tcpClient, SIGNAL(connectFailed(QString)), this, SLOT(connectFailed(QString)));
 }
 
 TcpClient* Session::getTcpClient() {
@@ -165,4 +165,26 @@ void Session::bindScriptService() {
 void Session::bindMainWindow() {
     // Connect events from xmlparser to MainWindow.
     connect(xmlParser, SIGNAL(setMainTitle(QString)), mainWindow, SLOT(setMainTitle(QString)));
+}
+
+void Session::connectAvailable(bool enable) {
+    mainWindow->enableConnectButton(enable);
+}
+
+void Session::connectStarted() {
+    mainWindow->getWindowFacade()->writeGameWindow("Connecting ...");
+}
+
+void Session::connectSucceeded() {
+    mainWindow->getWindowFacade()->writeGameWindow("Connection established.<br/>");
+}
+
+void Session::connectFailed(QString reason) {
+    mainWindow->getWindowFacade()->writeGameWindow("<br><br>"
+                                                   "*<br>"
+                                                   "* "
+                                                   + reason.toLocal8Bit()
+                                                   + "<br>"
+                                                     "*<br>"
+                                                     "<br><br>");
 }

--- a/gui/session.cpp
+++ b/gui/session.cpp
@@ -5,14 +5,40 @@
 #include "xml/xmlparserthread.h"
 #include "lich/lich.h"
 
+// classes we connect events from xmlparser to
+#include "vitalsbar.h"
+#include "toolbar/toolbar.h"
+#include "commandline.h"
+#include "roundtimedisplay.h"
+#include "windowfacade.h"
+#include "window/conversationswindow.h"
+#include "window/roomwindow.h"
+#include "window/expwindow.h"
+#include "window/deathswindow.h"
+#include "window/thoughtswindow.h"
+#include "window/arrivalswindow.h"
+#include "window/familiarwindow.h"
+#include "window/spellwindow.h"
+#include "window/atmosphericswindow.h"
+#include "window/groupwindow.h"
+#include "window/combatwindow.h"
+#include "scriptservice.h"
+
 Session::Session(MainWindow* parent, bool debug)
     : QObject(parent), mainWindow(static_cast<MainWindow*>(parent)) {
     lich = new Lich(mainWindow);
     tcpClient = new TcpClient(this, lich, debug);
     xmlParser = new XmlParserThread(mainWindow);
-    
-    setupParserAndClient();
-    setupClientStatus();
+
+    bindParserAndClient();
+    bindClientStatus();
+    bindVitalsBar();
+    bindToolBar();
+    bindCommandLine();
+    bindWindowFacade();
+    bindWindows();
+    bindScriptService();
+    bindMainWindow();
 
     if (!xmlParser->isRunning()) {
         xmlParser->start();
@@ -21,7 +47,7 @@ Session::Session(MainWindow* parent, bool debug)
     tcpClient->init();
 }
 
-void Session::setupParserAndClient() {
+void Session::bindParserAndClient() {
     // Connect XML parses and TCP Client
     connect(tcpClient, SIGNAL(addToQueue(QByteArray)), xmlParser, SLOT(addData(QByteArray)));
     connect(tcpClient, SIGNAL(diconnected()), xmlParser, SLOT(flushStream()));
@@ -32,8 +58,9 @@ void Session::setupParserAndClient() {
     connect(xmlParser, SIGNAL(gameModeIsCmgr(bool)), tcpClient, SLOT(setGameModeCmgr(bool)));
 }
 
-void Session::setupClientStatus() {
-    // Connect to TCP Client events and connect it to our events
+void Session::bindClientStatus() {
+    // Connect TCP Client events to main window events, to
+    // report status
     connect(tcpClient, SIGNAL(connectAvailable(bool)), mainWindow, SLOT(connectEnabled(bool)));
     connect(tcpClient, SIGNAL(connectStarted()), mainWindow, SLOT(connectStarted()));
     connect(tcpClient, SIGNAL(connectSucceeded()), mainWindow, SLOT(connectSucceeded()));
@@ -50,4 +77,91 @@ void Session::openConnection(QString host, QString port, QString key) {
 
 void Session::openLocalConnection(QString port) {
     tcpClient->connectToLocalPort(port);
+}
+
+void Session::bindVitalsBar() {
+    // Connect events from xmlparser to vitals bar
+    connect(xmlParser, SIGNAL(updateVitals(QString, QString)), mainWindow->getVitalsBar(),
+            SLOT(updateVitals(QString, QString)));
+}
+
+void Session::bindToolBar() {
+    // Connect events from xmlparser to toolbar
+    connect(xmlParser, SIGNAL(updateVitals(QString, QString)), mainWindow->getToolbar(),
+            SLOT(updateVitals(QString, QString)));
+    connect(xmlParser, SIGNAL(updateStatus(QString, QString)), mainWindow->getToolbar(),
+            SLOT(updateStatus(QString, QString)));
+    connect(xmlParser, SIGNAL(updateWieldLeft(QString)), mainWindow->getToolbar(),
+            SLOT(updateWieldLeft(QString)));
+    connect(xmlParser, SIGNAL(updateWieldRight(QString)), mainWindow->getToolbar(),
+            SLOT(updateWieldRight(QString)));
+    connect(xmlParser, SIGNAL(updateSpell(QString)), mainWindow->getToolbar(),
+            SLOT(updateSpell(QString)));
+    connect(xmlParser, SIGNAL(updateActiveSpells(QStringList)), mainWindow->getToolbar(),
+            SLOT(updateActiveSpells(QStringList)));
+    connect(xmlParser, SIGNAL(clearActiveSpells()), mainWindow->getToolbar(),
+            SLOT(clearActiveSpells()));
+}
+
+void Session::bindCommandLine() {
+    // Connect events from xmlparser to command line UI
+    connect(xmlParser, SIGNAL(setTimer(int)), mainWindow->getCommandLine()->getRoundtimeDisplay(),
+            SLOT(setTimer(int)));
+    connect(xmlParser, SIGNAL(setCastTimer(int)),
+            mainWindow->getCommandLine()->getRoundtimeDisplay(), SLOT(setCastTimer(int)));
+}
+
+void Session::bindWindowFacade() {
+    // Connect events from xmlparser to WindowFacade
+    connect(xmlParser, SIGNAL(updateNavigationDisplay(DirectionsList)),
+            mainWindow->getWindowFacade(), SLOT(updateNavigationDisplay(DirectionsList)));
+    connect(xmlParser, SIGNAL(updateMapWindow(QString)), mainWindow->getWindowFacade(),
+            SLOT(updateMapWindow(QString)));
+    connect(xmlParser, SIGNAL(writeText(QByteArray, bool)), mainWindow->getWindowFacade(),
+            SLOT(writeGameText(QByteArray, bool)));
+    connect(xmlParser, SIGNAL(registerStreamWindow(QString, QString)),
+            mainWindow->getWindowFacade(), SLOT(registerStreamWindow(QString, QString)));
+    connect(xmlParser, SIGNAL(writeStreamWindow(QString, QString)), mainWindow->getWindowFacade(),
+            SLOT(writeStreamWindow(QString, QString)));
+    connect(xmlParser, SIGNAL(clearStreamWindow(QString)), mainWindow->getWindowFacade(),
+            SLOT(clearStreamWindow(QString)));
+}
+
+void Session::bindWindows() {
+    // Connect events from xmlparser to stand-alone windows
+    connect(xmlParser, SIGNAL(updateConversationsWindow(QString)),
+            mainWindow->getWindowFacade()->getConversationsWindow(), SLOT(write(QString)));
+    connect(xmlParser, SIGNAL(updateRoomWindow()), mainWindow->getWindowFacade()->getRoomWindow(),
+            SLOT(write()));
+    connect(xmlParser, SIGNAL(updateRoomWindowTitle(QString)),
+            mainWindow->getWindowFacade()->getRoomWindow(), SLOT(setTitle(QString)));
+    connect(xmlParser, SIGNAL(updateExpWindow(QString, QString)),
+            mainWindow->getWindowFacade()->getExpWindow(), SLOT(write(QString, QString)));
+    connect(xmlParser, SIGNAL(updateDeathsWindow(QString)),
+            mainWindow->getWindowFacade()->getDeathsWindow(), SLOT(write(QString)));
+    connect(xmlParser, SIGNAL(updateThoughtsWindow(QString)),
+            mainWindow->getWindowFacade()->getThoughtsWindow(), SLOT(write(QString)));
+    connect(xmlParser, SIGNAL(updateArrivalsWindow(QString)),
+            mainWindow->getWindowFacade()->getArrivalsWindow(), SLOT(write(QString)));
+    connect(xmlParser, SIGNAL(updateFamiliarWindow(QString)),
+            mainWindow->getWindowFacade()->getFamiliarWindow(), SLOT(write(QString)));
+    connect(xmlParser, SIGNAL(updateSpellWindow(QString)),
+            mainWindow->getWindowFacade()->getSpellWindow(), SLOT(write(QString)));
+    connect(xmlParser, SIGNAL(updateAtmosphericsWindow(QString)),
+            mainWindow->getWindowFacade()->getAtmosphericsWindow(), SLOT(write(QString)));
+    connect(xmlParser, SIGNAL(updateGroupWindow(QString)),
+            mainWindow->getWindowFacade()->getGroupWindow(), SLOT(write(QString)));
+    connect(xmlParser, SIGNAL(updateCombatWindow(QString)),
+            mainWindow->getWindowFacade()->getCombatWindow(), SLOT(write(QString)));
+}
+
+void Session::bindScriptService() {
+    // Connect events from xmlparser to script service
+    connect(xmlParser, SIGNAL(writeScriptMessage(QByteArray)), mainWindow->getScriptService(),
+            SLOT(writeScriptText(QByteArray)));
+}
+
+void Session::bindMainWindow() {
+    // Connect events from xmlparser to MainWindow.
+    connect(xmlParser, SIGNAL(setMainTitle(QString)), mainWindow, SLOT(setMainTitle(QString)));
 }

--- a/gui/session.cpp
+++ b/gui/session.cpp
@@ -4,6 +4,7 @@
 #include "tcpclient.h"
 #include "xml/xmlparserthread.h"
 #include "lich/lich.h"
+#include "gamedatacontainer.h"
 
 // classes we connect events from xmlparser to
 #include "vitalsbar.h"
@@ -28,7 +29,7 @@ Session::Session(MainWindow* parent, bool debug)
     : QObject(parent), mainWindow(static_cast<MainWindow*>(parent)) {
     lich = new Lich(mainWindow);
     tcpClient = new TcpClient(this, lich, debug);
-    xmlParser = new XmlParserThread(mainWindow);
+    xmlParser = new XmlParserThread(mainWindow, GameDataContainer::Instance());
 
     bindParserAndClient();
     bindClientStatus();

--- a/gui/session.cpp
+++ b/gui/session.cpp
@@ -3,19 +3,51 @@
 #include "mainwindow.h"
 #include "tcpclient.h"
 #include "xml/xmlparserthread.h"
+#include "lich/lich.h"
 
-Session::Session(MainWindow* parent, TcpClient* client, XmlParserThread* parser) : QObject(parent), tcpClient(client), xmlParser(parser) {
-    connect(tcpClient, SIGNAL(addToQueue(QByteArray)), xmlParser, SLOT(addData(QByteArray)));
-    connect(tcpClient, SIGNAL(diconnected()), xmlParser, SLOT(flushStream()));
-    connect(xmlParser, SIGNAL(writeSettings()), tcpClient, SLOT(writeSettings()));
-    connect(xmlParser, SIGNAL(writeModeSettings()), tcpClient, SLOT(writeModeSettings()));
-    connect(xmlParser, SIGNAL(writeDefaultSettings(QString)), tcpClient, SLOT(writeDefaultSettings(QString)));
-    connect(xmlParser, SIGNAL(gameModeIsCmgr(bool)), tcpClient, SLOT(setGameModeCmgr(bool)));
-
+Session::Session(MainWindow* parent, bool debug)
+    : QObject(parent), mainWindow(static_cast<MainWindow*>(parent)) {
+    lich = new Lich(mainWindow);
+    tcpClient = new TcpClient(this, lich, debug);
+    xmlParser = new XmlParserThread(mainWindow);
     
-    if(!xmlParser->isRunning()) {
+    setupParserAndClient();
+    setupClientStatus();
+
+    if (!xmlParser->isRunning()) {
         xmlParser->start();
     }
 
     tcpClient->init();
+}
+
+void Session::setupParserAndClient() {
+    // Connect XML parses and TCP Client
+    connect(tcpClient, SIGNAL(addToQueue(QByteArray)), xmlParser, SLOT(addData(QByteArray)));
+    connect(tcpClient, SIGNAL(diconnected()), xmlParser, SLOT(flushStream()));
+    connect(xmlParser, SIGNAL(writeSettings()), tcpClient, SLOT(writeSettings()));
+    connect(xmlParser, SIGNAL(writeModeSettings()), tcpClient, SLOT(writeModeSettings()));
+    connect(xmlParser, SIGNAL(writeDefaultSettings(QString)), tcpClient,
+            SLOT(writeDefaultSettings(QString)));
+    connect(xmlParser, SIGNAL(gameModeIsCmgr(bool)), tcpClient, SLOT(setGameModeCmgr(bool)));
+}
+
+void Session::setupClientStatus() {
+    // Connect to TCP Client events and connect it to our events
+    connect(tcpClient, SIGNAL(connectAvailable(bool)), mainWindow, SLOT(connectEnabled(bool)));
+    connect(tcpClient, SIGNAL(connectStarted()), mainWindow, SLOT(connectStarted()));
+    connect(tcpClient, SIGNAL(connectSucceeded()), mainWindow, SLOT(connectSucceeded()));
+    connect(tcpClient, SIGNAL(connectFailed(QString)), mainWindow, SLOT(connectFailed(QString)));
+}
+
+TcpClient* Session::getTcpClient() {
+    return tcpClient;
+}
+
+void Session::openConnection(QString host, QString port, QString key) {
+    tcpClient->connectToHost(host, port, key);
+}
+
+void Session::openLocalConnection(QString port) {
+    tcpClient->connectToLocalPort(port);
 }

--- a/gui/session.h
+++ b/gui/session.h
@@ -20,8 +20,15 @@ public:
     void openConnection(QString host, QString port, QString key);
     void openLocalConnection(QString port);
 private:
-    void setupParserAndClient();
-    void setupClientStatus();
+    void bindParserAndClient();
+    void bindClientStatus();
+    void bindVitalsBar();
+    void bindToolBar();
+    void bindCommandLine();
+    void bindWindowFacade();
+    void bindWindows();
+    void bindScriptService();
+    void bindMainWindow();
 
     Lich* lich;
     TcpClient* tcpClient;

--- a/gui/session.h
+++ b/gui/session.h
@@ -3,7 +3,6 @@
 
 #include <QObject>
 
-
 class MainWindow;
 class TcpClient;
 class XmlParserThread;
@@ -19,6 +18,14 @@ public:
 
     void openConnection(QString host, QString port, QString key);
     void openLocalConnection(QString port);
+
+private slots:
+    // Connect statuses from tcp client
+    void connectAvailable(bool);
+    void connectStarted();
+    void connectSucceeded();
+    void connectFailed(QString);
+
 private:
     void bindParserAndClient();
     void bindClientStatus();
@@ -35,8 +42,6 @@ private:
     XmlParserThread* xmlParser;
 
     MainWindow* mainWindow;
-signals:
-    
 };
 
 #endif

--- a/gui/session.h
+++ b/gui/session.h
@@ -7,17 +7,27 @@
 class MainWindow;
 class TcpClient;
 class XmlParserThread;
+class Lich;
 
 class Session : public QObject {
     Q_OBJECT
 public:
-    Session(MainWindow* parent, TcpClient* client, XmlParserThread* parser);
+    Session(MainWindow* parent, bool debug);
     ~Session() = default;
 
+    TcpClient* getTcpClient();
+
+    void openConnection(QString host, QString port, QString key);
+    void openLocalConnection(QString port);
 private:
+    void setupParserAndClient();
+    void setupClientStatus();
+
+    Lich* lich;
     TcpClient* tcpClient;
     XmlParserThread* xmlParser;
-    MainWindow* mainWindow;    
+
+    MainWindow* mainWindow;
 signals:
     
 };

--- a/gui/session.h
+++ b/gui/session.h
@@ -1,0 +1,25 @@
+#ifndef SESSION_H
+#define SESSION_H
+
+#include <QObject>
+
+
+class MainWindow;
+class TcpClient;
+class XmlParserThread;
+
+class Session : public QObject {
+    Q_OBJECT
+public:
+    Session(MainWindow* parent, TcpClient* client, XmlParserThread* parser);
+    ~Session() = default;
+
+private:
+    TcpClient* tcpClient;
+    XmlParserThread* xmlParser;
+    MainWindow* mainWindow;    
+signals:
+    
+};
+
+#endif

--- a/gui/tcpclient.cpp
+++ b/gui/tcpclient.cpp
@@ -9,7 +9,8 @@
 #include "lich/lich.h"
 #include "environment.h"
 
-TcpClient::TcpClient(QObject *parent, bool loadMock) : QObject(parent) {
+TcpClient::TcpClient(QObject* parent, Lich* lichClient, bool loadMock)
+    : QObject(parent), lich(lichClient), useMock(loadMock) {
     tcpSocket = new QTcpSocket(this);
     eAuth = new EAuthService(this);
     // TODO: Remove dependency on ClientSettings
@@ -18,23 +19,18 @@ TcpClient::TcpClient(QObject *parent, bool loadMock) : QObject(parent) {
     settings = ClientSettings::getInstance();
     api = false;
     apiLich = false;
-    useMock = loadMock;
 
     commandPrefix = "<c>";
 
     debugLogger = new DebugLogger();
 
-    // TODO: We can use dependency injection here
-    lich = new Lich(parent);
-
-    if(tcpSocket) {
-        connect(tcpSocket, SIGNAL(readyRead()), this, SLOT(socketReadyRead()));
-        connect(tcpSocket, SIGNAL(error(QAbstractSocket::SocketError)), this, SLOT(socketError(QAbstractSocket::SocketError)));
-        connect(tcpSocket, SIGNAL(disconnected()), this, SLOT(disconnectedFromHost()));
-        connect(tcpSocket, SIGNAL(connected()), this, SLOT(connectedToHost()));
-        tcpSocket->setSocketOption(QAbstractSocket::LowDelayOption, 1);
-        tcpSocket->setSocketOption(QAbstractSocket::KeepAliveOption, 1);
-    }    
+    connect(tcpSocket, SIGNAL(readyRead()), this, SLOT(socketReadyRead()));
+    connect(tcpSocket, SIGNAL(error(QAbstractSocket::SocketError)), this,
+            SLOT(socketError(QAbstractSocket::SocketError)));
+    connect(tcpSocket, SIGNAL(disconnected()), this, SLOT(disconnectedFromHost()));
+    connect(tcpSocket, SIGNAL(connected()), this, SLOT(connectedToHost()));
+    tcpSocket->setSocketOption(QAbstractSocket::LowDelayOption, 1);
+    tcpSocket->setSocketOption(QAbstractSocket::KeepAliveOption, 1);
 }
 
 void TcpClient::init() {

--- a/gui/tcpclient.cpp
+++ b/gui/tcpclient.cpp
@@ -12,6 +12,9 @@
 TcpClient::TcpClient(QObject *parent, bool loadMock) : QObject(parent) {
     tcpSocket = new QTcpSocket(this);
     eAuth = new EAuthService(this);
+    // TODO: Remove dependency on ClientSettings
+    // settings only needed to get the current debug flag.
+    // Probably emit a message instead ?
     settings = ClientSettings::getInstance();
     api = false;
     apiLich = false;
@@ -21,6 +24,7 @@ TcpClient::TcpClient(QObject *parent, bool loadMock) : QObject(parent) {
 
     debugLogger = new DebugLogger();
 
+    // TODO: We can use dependency injection here
     lich = new Lich(parent);
 
     if(tcpSocket) {

--- a/gui/tcpclient.cpp
+++ b/gui/tcpclient.cpp
@@ -39,10 +39,6 @@ void TcpClient::init() {
     }
 }
 
-void TcpClient::reloadSettings() {
-    emit updateHighlighterSettings();
-}
-
 void TcpClient::loadMockData() {
     QFile file(MOCK_DATA_PATH);
 

--- a/gui/tcpclient.cpp
+++ b/gui/tcpclient.cpp
@@ -154,12 +154,12 @@ bool TcpClient::connectToHost(QString sessionHost, QString sessionPort, QString 
     commandPrefix = "<c>";
 
     tcpSocket->connectToHost(sessionHost, sessionPort.toInt());
-    bool conntected = tcpSocket->waitForConnected();
+    bool connected = tcpSocket->waitForConnected();
 
     this->writeCommand(sessionKey);
     this->writeCommand("/FE:STORMFRONT /VERSION:1.0.1.26 /P:WIN_UNKNOWN /XML");
 
-    return conntected;
+    return connected;
 }
 
 void TcpClient::disconnectedFromHost() {

--- a/gui/tcpclient.cpp
+++ b/gui/tcpclient.cpp
@@ -9,7 +9,7 @@
 #include "lich/lich.h"
 #include "environment.h"
 
-TcpClient::TcpClient(QObject *parent) : QObject(parent) {
+TcpClient::TcpClient(QObject *parent, bool debug) : QObject(parent) {
     tcpSocket = new QTcpSocket(this);
     eAuth = new EAuthService(this);
     settings = ClientSettings::getInstance();
@@ -39,7 +39,7 @@ TcpClient::TcpClient(QObject *parent) : QObject(parent) {
     connect(xmlParser, SIGNAL(writeModeSettings()), this, SLOT(writeModeSettings()));
     connect(xmlParser, SIGNAL(writeDefaultSettings(QString)), this, SLOT(writeDefaultSettings(QString)));
 
-    if(settings->isDebug()) {
+    if(debug) {
         this->loadMockData();
     }
 }

--- a/gui/tcpclient.h
+++ b/gui/tcpclient.h
@@ -5,8 +5,6 @@
 #include <QtNetwork/QNetworkProxy>
 #include <QDebug>
 
-class MainWindow;
-class WindowFacade;
 class ClientSettings;
 class EAuthService;
 class XmlParserThread;
@@ -29,10 +27,8 @@ public:
                     QString game, QString character, bool apiLich);
 
 private:
-    MainWindow *mainWindow;
     QTcpSocket *tcpSocket;
     QByteArray buffer;
-    WindowFacade *windowFacade;
     ClientSettings *settings;
     EAuthService *eAuth;
     QString sessionKey;
@@ -61,7 +57,10 @@ signals:
     void resetPassword();
     void enableGameSelect();
     void setGameList(QMap<QString, QString>);
-
+    void connectAvailable(bool);
+    void connectStarted();
+    void connectSucceeded();
+    void connectFailed(QString);
 public slots:
     void setProxy(bool, QString, QString);
     void socketReadyRead();

--- a/gui/tcpclient.h
+++ b/gui/tcpclient.h
@@ -15,7 +15,7 @@ class TcpClient : public QObject {
     Q_OBJECT
 
 public:
-    TcpClient(QObject *parent = 0);
+    TcpClient(QObject *parent = 0, bool debug = false);
     ~TcpClient();
 
     void writeCommand(QString);

--- a/gui/tcpclient.h
+++ b/gui/tcpclient.h
@@ -15,7 +15,7 @@ class TcpClient : public QObject {
     Q_OBJECT
 
 public:
-    TcpClient(QObject *parent = 0, bool loadMock = false);
+    TcpClient(QObject *parent = 0, Lich* lichClient = 0, bool loadMock = false);
     ~TcpClient();
     void init();
 

--- a/gui/tcpclient.h
+++ b/gui/tcpclient.h
@@ -15,8 +15,9 @@ class TcpClient : public QObject {
     Q_OBJECT
 
 public:
-    TcpClient(QObject *parent = 0, bool debug = false);
+    TcpClient(QObject *parent = 0, bool loadMock = false);
     ~TcpClient();
+    void init();
 
     void writeCommand(QString);
     void showError(QString);
@@ -32,7 +33,6 @@ private:
     ClientSettings *settings;
     EAuthService *eAuth;
     QString sessionKey;
-    XmlParserThread* xmlParser;
     DebugLogger* debugLogger;
     QByteArray commandPrefix;
 
@@ -44,7 +44,9 @@ private:
     QString character;
     bool api;
     bool apiLich;
-
+    bool isCmgr = false;
+    bool useMock = false;
+    
 signals:
     void characterFound(QString, QString);
     void retrieveSessionKey(QString);
@@ -84,6 +86,7 @@ public slots:
     void writeDefaultSettings(QString);
     void writeModeSettings();
     void reloadSettings();
+    void setGameModeCmgr(bool);
 };
 
 

--- a/gui/tcpclient.h
+++ b/gui/tcpclient.h
@@ -55,7 +55,6 @@ signals:
     void eAuthError(QString);
     void addToQueue(QByteArray);
     void diconnected();
-    void updateHighlighterSettings();
     void resetPassword();
     void enableGameSelect();
     void setGameList(QMap<QString, QString>);
@@ -85,7 +84,6 @@ public slots:
     void writeSettings();
     void writeDefaultSettings(QString);
     void writeModeSettings();
-    void reloadSettings();
     void setGameModeCmgr(bool);
 };
 

--- a/gui/text/alter/alter.cpp
+++ b/gui/text/alter/alter.cpp
@@ -3,7 +3,7 @@
 #include "text/alter/substitutionsettings.h"
 #include "text/alter/ignoresettings.h"
 #include "text/alter/linksettings.h"
-#include "hyperlinkservice.h"
+#include "hyperlinkutils.h"
 #include "globaldefines.h"
 
 Alter::Alter(QObject *parent) : QObject(parent) {
@@ -56,7 +56,7 @@ QString Alter::addLink(QString text, QString window) {
         for(AlterSettingsEntry entry : linkList) {
             if(!entry.enabled || entry.pattern.isEmpty() || entry.value.isEmpty()) continue;
             if(!entry.targetList.empty() && !entry.targetList.contains(window)) continue;
-            HyperlinkService::addLink(text, entry.pattern, entry.value);
+            HyperlinkUtils::addLink(text, entry.pattern, entry.value);
         }
     }
     return text;

--- a/gui/text/alter/alter.h
+++ b/gui/text/alter/alter.h
@@ -35,7 +35,6 @@ private:
      LinkSettings* linkSettings;
      bool ignoreEnabled;
 
-     int createLink(AlterSettingsEntry entry, QString &text, int indexStart, QString match);
      QString createCommand(QString text, QString command);
 
 signals:

--- a/gui/toolbar/toolbar.cpp
+++ b/gui/toolbar/toolbar.cpp
@@ -15,6 +15,7 @@
 #include "clientsettings.h"
 #include "commandline.h"
 #include "textutils.h"
+#include "text/highlight/highlighter.h"
 
 Toolbar::Toolbar(QObject *parent) : QObject(parent) {
     mainWindow = (MainWindow*)parent;
@@ -28,8 +29,9 @@ Toolbar::Toolbar(QObject *parent) : QObject(parent) {
     wieldRight = new WieldIndicator(this, RHAND_ICO);
     spell = new SpellIndicator(this);            
     activeSpell = new ActiveSpellIndicator(this);
+    highlighter = new Highlighter(parent);
 
-    connect(mainWindow, SIGNAL(profileChanged()), this, SLOT(reloadSettings()));   
+    connect(mainWindow, SIGNAL(profileChanged()), this, SLOT(reloadSettings()));
 }
 
 void Toolbar::reloadSettings() {
@@ -160,10 +162,14 @@ void Toolbar::updateVitals(QString name, QString value) {
         vitalsIndicator->manaBar->setToolTip("Mana: " + value + "%");
         vitalsIndicator->manaBar->repaint();
     }
+    highlighter->alert(name, intValue);
 }
 
 void Toolbar::updateStatus(QString visible, QString icon) {
     statusIndicator->updateStatus(visible, icon);
+    if (visible == "y") {
+        highlighter->alert(icon);
+    }
 }
 
 int Toolbar::getHealthValue() {

--- a/gui/toolbar/toolbar.h
+++ b/gui/toolbar/toolbar.h
@@ -16,6 +16,7 @@ class StatusIndicator;
 class ActiveSpellIndicator;
 class SpellIndicator;
 class ClientSettings;
+class Highlighter;
 
 class Toolbar : public QObject {
     Q_OBJECT
@@ -47,6 +48,7 @@ private:
     SpellIndicator* spell;
     ActiveSpellIndicator* activeSpell;
     MuteButton* muteButton;
+    Highlighter* highlighter;
 
     ClientSettings* clientSettings;
 

--- a/gui/windowfacade.cpp
+++ b/gui/windowfacade.cpp
@@ -442,8 +442,9 @@ void WindowFacade::logGameText(QByteArray text, char type) {
 }
 
 void WindowFacade::registerStreamWindow(QString id, QString title) {
-    if(streamWindows.contains(id)) return;
-
+    // Check if window has been registered (or it is a static window)
+    if(streamWindows.contains(id) || staticWindows.contains(id)) return;
+    
     QDockWidget* streamWindow = genericWindowFactory->createWindow(title.toLatin1().constData());
     ((GenericWindow*)streamWindow->widget())->setStream(true);
     mainWindow->addDockWidgetMainWindow(Qt::RightDockWidgetArea, streamWindow);
@@ -483,7 +484,10 @@ void WindowFacade::writeStreamWindow(QString id, QString text) {
 }
 
 void WindowFacade::clearStreamWindow(QString id) {
-    this->writeStreamWindow(id, "{clear}");
+    // Do not clear static windows
+    if (!staticWindows.contains(id)) {
+        this->writeStreamWindow(id, "{clear}");
+    }
 }
 
 void WindowFacade::lockWindows() {

--- a/gui/xml/xmlparserthread.cpp
+++ b/gui/xml/xmlparserthread.cpp
@@ -1,17 +1,13 @@
 #include "xmlparserthread.h"
 
-#include "mainwindow.h"
+#include <QXmlStreamReader>
+
 #include "gamedatacontainer.h"
-#include "text/highlight/highlighter.h"
 #include "textutils.h"
 #include "hyperlinkservice.h"
 
-XmlParserThread::XmlParserThread(QObject *parent) {
-    mainWindow = (MainWindow*)parent;
+XmlParserThread::XmlParserThread(QObject *parent) : Parent(parent) {
     gameDataContainer = GameDataContainer::Instance();
-    // TODO: Do we really need Highlighter as a part of a parser?
-    // Maybe emit a signal when appropriate?
-    highlighter = new Highlighter(parent);
 
     rxDmg.setPattern("\\bat you\\..*\\blands\\b");
     
@@ -306,7 +302,6 @@ bool XmlParserThread::filterDataTags(QDomElement root, QDomNode n) {
             /* filter vitals */
             QDomElement vitalsElement = root.firstChildElement("dialogData").firstChildElement("progressBar");
             emit updateVitals(vitalsElement.attribute("id"), vitalsElement.attribute("value"));
-            highlighter->alert(vitalsElement.attribute("id"), vitalsElement.attribute("value").toInt());
         } else if(e.tagName() == "dialogData" && e.attribute("id") == "spellChoose") {
             QDomElement closeButton = e.firstChildElement("closeButton");
             gameText += closeButton.attribute("value") + ": [<span class=\"bold\">" + closeButton.attribute("cmd") + "</span>]";
@@ -314,9 +309,6 @@ bool XmlParserThread::filterDataTags(QDomElement root, QDomNode n) {
             /* filter player status indicator */
             //<indicator id="IconKNEELING" visible="n"/><indicator id="IconPRONE" visible="n"/>
             emit updateStatus(e.attribute("visible"), e.attribute("id"));
-            if(e.attribute("visible") == "y") {
-                highlighter->alert(e.attribute("id"));
-            }
         } else if(e.tagName() == "left") {
             /* filter player wielding in left hand */
             emit updateWieldLeft(e.text());

--- a/gui/xml/xmlparserthread.cpp
+++ b/gui/xml/xmlparserthread.cpp
@@ -4,11 +4,9 @@
 
 #include "gamedatacontainer.h"
 #include "textutils.h"
-#include "hyperlinkservice.h"
+#include "hyperlinkutils.h"
 
-XmlParserThread::XmlParserThread(QObject *parent) : Parent(parent) {
-    gameDataContainer = GameDataContainer::Instance();
-
+XmlParserThread::XmlParserThread(QObject *parent, GameDataContainer* dataContainer) : Parent(parent), gameDataContainer(dataContainer) {
     rxDmg.setPattern("\\bat you\\..*\\blands\\b");
     
     bold = false;
@@ -120,7 +118,7 @@ QString XmlParserThread::processCommands(QString line) {
             lastPos = endPos;
             QString cmd = match.captured(1);
             QString text = match.captured(2);
-            HyperlinkService::createLink(text, cmd, 0, text);
+            HyperlinkUtils::createLink(text, cmd, 0, text);
             newLine.append(text);
         } while (i.hasNext());
         // append the rest
@@ -209,7 +207,7 @@ bool XmlParserThread::filterPlainText(QDomElement root, QDomNode n) {
         QString d = e.text().trimmed();
         QString cmd  = e.attribute("cmd", d);
         TextUtils::plainToHtml(d);
-        HyperlinkService::createLink(d, cmd, 0, d);
+        HyperlinkUtils::createLink(d, cmd, 0, d);
         gameText += d;
     } else if(e.tagName() == "preset" && e.attribute("id") == "roomDesc") {
         QString preset = e.text().trimmed();
@@ -269,10 +267,10 @@ bool XmlParserThread::filterDataTags(QDomElement root, QDomNode n) {
             }
             qSort(directions);
 
-            GameDataContainer::Instance()->setCompassDirections(directions);
+            gameDataContainer->setCompassDirections(directions);
 
-            QString text = GameDataContainer::Instance()->getRoomName() +
-                    TextUtils::stripMapSpecial(GameDataContainer::Instance()->getRoomDesc())
+            QString text = gameDataContainer->getRoomName() +
+                    TextUtils::stripMapSpecial(gameDataContainer->getRoomDesc())
                     + directions.join("");
 
             QString hash = TextUtils::toHash(text);

--- a/gui/xml/xmlparserthread.cpp
+++ b/gui/xml/xmlparserthread.cpp
@@ -80,7 +80,6 @@ XmlParserThread::XmlParserThread(QObject *parent) {
     charName = "";
 
     mono = false;
-    cmgr = false;
 
     pushStream = false;
 }
@@ -91,12 +90,6 @@ void XmlParserThread::updateHighlighterSettings() {
 
 void XmlParserThread::addData(QByteArray buffer) {
     Parent::addData(buffer);
-}
-
-
-bool XmlParserThread::isCmgr() {
-    bool result = cmgr;
-    return result;
 }
 
 QString XmlParserThread::fixInputXml(QString data) {
@@ -247,14 +240,14 @@ bool XmlParserThread::filterPlainText(QDomElement root, QDomNode n) {
     /* Process game text with start tag only */        
     if(e.tagName() == "mode") {
         if(e.attribute("id") == "GAME") {
-            cmgr = false;
+            emit gameModeIsCmgr(false);
             stormfrontSettings = toString(n.nextSiblingElement()).trimmed();
         } else if(e.attribute("id") == "CMGR") {
-            cmgr = true;
+            emit gameModeIsCmgr(true);
             gameDataContainer->setRoomDesc("");
             emit updateRoomWindow();
         } else {
-            cmgr = false;
+            emit gameModeIsCmgr(false);
         }
     } if(e.tagName() == "settingsInfo") {
         emit writeModeSettings();

--- a/gui/xml/xmlparserthread.cpp
+++ b/gui/xml/xmlparserthread.cpp
@@ -84,10 +84,6 @@ XmlParserThread::XmlParserThread(QObject *parent) {
     pushStream = false;
 }
 
-void XmlParserThread::updateHighlighterSettings() {
-    highlighter->reloadSettings();
-}
-
 void XmlParserThread::addData(QByteArray buffer) {
     Parent::addData(buffer);
 }

--- a/gui/xml/xmlparserthread.h
+++ b/gui/xml/xmlparserthread.h
@@ -32,7 +32,6 @@ private:
     bool filterDataTags(QDomElement, QDomNode);
 
     GameDataContainer* gameDataContainer;
-    QStringList inventory;
 
     QString gameText;
     QDateTime time;    

--- a/gui/xml/xmlparserthread.h
+++ b/gui/xml/xmlparserthread.h
@@ -29,8 +29,6 @@ public:
     explicit XmlParserThread(QObject *parent = 0);
     ~XmlParserThread() = default;
 
-    bool isCmgr();
-
     void process(QString);
 protected:
     void onProcess(const QByteArray& data) override;
@@ -70,7 +68,6 @@ private:
     QString streamCache;
 
     bool mono;
-    QAtomicInt cmgr;
 
     bool pushStream;
 
@@ -142,7 +139,9 @@ signals:
 
     void registerStreamWindow(QString, QString);
     void writeStreamWindow(QString, QString);
-    void clearStreamWindow(QString);    
+    void clearStreamWindow(QString);
+
+    void gameModeIsCmgr(bool);
 
 public slots:
     void addData(QByteArray);

--- a/gui/xml/xmlparserthread.h
+++ b/gui/xml/xmlparserthread.h
@@ -12,9 +12,7 @@
 
 #include "workqueuethread.h"
 
-class MainWindow;
 class GameDataContainer;
-class Highlighter;
 
 typedef QList<QString> DirectionsList;
 
@@ -33,9 +31,7 @@ private:
     bool filterPlainText(QDomElement, QDomNode);
     bool filterDataTags(QDomElement, QDomNode);
 
-    MainWindow* mainWindow;
     GameDataContainer* gameDataContainer;
-    Highlighter* highlighter;
     QStringList inventory;
 
     QString gameText;

--- a/gui/xml/xmlparserthread.h
+++ b/gui/xml/xmlparserthread.h
@@ -20,7 +20,7 @@ class XmlParserThread : public WorkQueueThread<QByteArray> {
     Q_OBJECT
     using Parent = WorkQueueThread<QByteArray>;
 public:
-    explicit XmlParserThread(QObject *parent = 0);
+    explicit XmlParserThread(QObject *parent, GameDataContainer* dataContainer);
     ~XmlParserThread() = default;
 
     void process(QString);

--- a/gui/xml/xmlparserthread.h
+++ b/gui/xml/xmlparserthread.h
@@ -146,7 +146,6 @@ signals:
 public slots:
     void addData(QByteArray);
     void flushStream();
-    void updateHighlighterSettings();
 };
 
 #endif // XMLPARSERTHREAD_H

--- a/gui/xml/xmlparserthread.h
+++ b/gui/xml/xmlparserthread.h
@@ -13,12 +13,8 @@
 #include "workqueuethread.h"
 
 class MainWindow;
-class WindowFacade;
-class Toolbar;
-class CommandLine;
 class GameDataContainer;
 class Highlighter;
-class VitalsBar;
 
 typedef QList<QString> DirectionsList;
 
@@ -38,10 +34,6 @@ private:
     bool filterDataTags(QDomElement, QDomNode);
 
     MainWindow* mainWindow;
-    WindowFacade* windowFacade;
-    Toolbar* toolBar;
-    VitalsBar* vitalsBar;
-    CommandLine* commandLine;
     GameDataContainer* gameDataContainer;
     Highlighter* highlighter;
     QStringList inventory;


### PR DESCRIPTION
This pull request is build on top of network-decoupling, and, as it is a new feature, should **not** go in before the release.
Only 2 last commits are from the actual pull-request, the rest are from network-decoupling branch.
The pull request improves the TCP communication with Frostbite by introducing 2 new commands in TCP ServerAPI: PUT COMMAND and PUT ECHO, working the same way as the same script commands, to allow execution of the commands from TCP client.
Another change is a new ScriptStreamingServer, which is a read-only server which streams the game data into the TCP connection in plain text format (as a scriptservice does). The server is optional and turned off by default.
These 2 changes allows implementing scripting clients/engines for the Frostbite using simple plain text protocol over TCP via 2 sockets - one for commands and one for streaming of the data.