### PR TITLE
Fix for the issue #101

### DIFF
--- a/gui/windowfacade.cpp
+++ b/gui/windowfacade.cpp
@@ -459,9 +459,9 @@ void WindowFacade::removeStreamWindow(QString id) {
     if(!streamWindows.contains(id)) return;
 
     WindowWriterThread* writer = streamWriters.value(id);
-    writer->wait();
-    delete writer;
     streamWriters.remove(id);
+    delete writer;
+
 
     QDockWidget* window = streamWindows.value(id);
     mainWindow->removeDockWidgetMainWindow(window);


### PR DESCRIPTION
Removed waiting before deleting the window writer thread.
Now Frostbite is not crashing while removing the streaming window.